### PR TITLE
Tile menu filter

### DIFF
--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -117,5 +117,11 @@ namespace Content.Shared.Maps
         {
             TileId = id;
         }
+
+        /// <summary>
+        /// CrystallPunk Tile filtering
+        /// </summary>
+        [DataField]
+        public bool EditorHidden { get; private set; } = true;
     }
 }

--- a/Resources/Prototypes/_CP14/Tiles/base.yml
+++ b/Resources/Prototypes/_CP14/Tiles/base.yml
@@ -11,6 +11,7 @@
 #   - other produced tiles
 
 - type: tile
+  editorHidden: false
   id: CP14FloorBase
   name: cp14-tiles-base
   sprite: /Textures/_CP14/Tiles/cave.png

--- a/Resources/Prototypes/_CP14/Tiles/natural.yml
+++ b/Resources/Prototypes/_CP14/Tiles/natural.yml
@@ -1,4 +1,5 @@
 - type: tile
+  editorHidden: false
   id: CP14FloorDirt
   name: cp14-tiles-dirt
   sprite: /Textures/_CP14/Tiles/cavedrought.png
@@ -29,6 +30,7 @@
 
 - type: tile
   id: CP14FloorGrass
+  editorHidden: false
   name: cp14-tiles-grass
   sprite: /Textures/Tiles/Planet/Grass/grass.png
   variants: 4

--- a/Resources/Prototypes/_CP14/Tiles/produced.yml
+++ b/Resources/Prototypes/_CP14/Tiles/produced.yml
@@ -1,4 +1,5 @@
 - type: tile
+  editorHidden: false
   id: CP14FloorFoundation
   name: cp14-tiles-foundation
   sprite: /Textures/_CP14/Tiles/foundation.png
@@ -16,6 +17,7 @@
   weather: false
 
 - type: tile
+  editorHidden: false
   id: CP14FloorWoodPlanks
   name: cp14-tiles-woodplanks
   sprite: /Textures/_CP14/Tiles/woodplanks.png
@@ -33,6 +35,7 @@
   weather: false
 
 - type: tile
+  editorHidden: false
   id: CP14FloorWoodPlanksBig
   name: cp14-tiles-woodplanks-big
   sprite: /Textures/_CP14/Tiles/woodplanks_big.png
@@ -50,6 +53,7 @@
   weather: false
 
 - type: tile
+  editorHidden: false
   id: CP14FloorStonebricks
   name: cp14-tiles-stonebricks
   sprite: /Textures/_CP14/Tiles/stonebricks.png
@@ -64,6 +68,7 @@
   weather: false
 
 - type: tile
+  editorHidden: false
   id: CP14FloorStonebricksSmallCarved1
   name: cp14-tiles-stonebricks-small-carved1
   sprite: /Textures/_CP14/Tiles/stonebricks_small_carved_1.png
@@ -78,6 +83,7 @@
   weather: false
 
 - type: tile
+  editorHidden: false
   id: CP14FloorStonebricksSmallCarved2
   name: cp14-tiles-stonebricks-small-carved2
   sprite: /Textures/_CP14/Tiles/stonebricks_small_carved_2.png
@@ -92,6 +98,7 @@
   weather: false
 
 - type: tile
+  editorHidden: false
   id: CP14FloorStonebricksSquareCarved
   name: cp14-tiles-stonebricks-square-carved
   sprite: /Textures/_CP14/Tiles/stonebricks_square_carved.png


### PR DESCRIPTION
![image](https://github.com/crystallpunk-14/crystall-punk-14/assets/96445749/c5809f15-e50a-45e3-b7bb-56e96025e78b)

The tile spawn menu now contains only those tiles that are used by the project.