### PR TITLE
Fix can't draw from the water on the floor

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Structures/Flora/floorWater.yml
+++ b/Resources/Prototypes/_CP14/Entities/Structures/Flora/floorWater.yml
@@ -45,6 +45,8 @@
       collection: FootstepWater
       params:
         volume: 8
+  - type: DrawableSolution
+    solution: pool
   - type: SolutionContainerManager
     solutions:
       pool:


### PR DESCRIPTION
## About the PR

Fixes #189 

Small fix, that allows to draw water from the floorwater.

Маленький фикс, позволяющий черпать воду из floorwater.

## Media

Счастливый обладатель бесконечных запасов воды, фото в цвете:

![image](https://github.com/crystallpunk-14/crystall-punk-14/assets/38111072/d96ed9b0-720a-480d-b1e9-b3d48776783f)
