### PR TITLE
Wallmount update

### DIFF
--- a/Content.Shared/_CP14/Wallmount/CP14WallRequired.cs
+++ b/Content.Shared/_CP14/Wallmount/CP14WallRequired.cs
@@ -1,0 +1,48 @@
+using Content.Shared.Construction;
+using Content.Shared.Construction.Conditions;
+using Content.Shared.Tag;
+using JetBrains.Annotations;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+
+namespace Content.Shared._CP14.Wallmount;
+
+[UsedImplicitly]
+[DataDefinition]
+public sealed partial class CP14WallRequired : IConstructionCondition
+{
+    public ConstructionGuideEntry GenerateGuideEntry()
+    {
+        return new ConstructionGuideEntry
+        {
+            Localization = "cp14-construction-step-condition-wall-required",
+        };
+    }
+
+    public bool Condition(EntityUid user, EntityCoordinates location, Direction direction)
+    {
+        var entityManager = IoCManager.Resolve<IEntityManager>();
+        var mapSystem = entityManager.System<SharedMapSystem>();
+        var transformSystem = entityManager.System<SharedTransformSystem>();
+        var tagSystem = entityManager.System<TagSystem>();
+        var grid = transformSystem.GetGrid(user);
+
+        if (grid == null || !entityManager.TryGetComponent<MapGridComponent>(grid, out var gridComp))
+            return false;
+
+        var offset = direction.ToAngle().ToWorldVec();
+        var targetPos = location.Offset(-offset);
+        var anchored = mapSystem.GetAnchoredEntities(grid.Value, gridComp, targetPos);
+
+        bool hasParent = false;
+        foreach (var entt in anchored)
+        {
+            if (!tagSystem.HasAnyTag(entt, CP14WallmountSystem.WallTags))
+                continue;
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Content.Shared/_CP14/Wallmount/CP14WallmountComponent.cs
+++ b/Content.Shared/_CP14/Wallmount/CP14WallmountComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Shared._CP14.Wallmount;
+
+/// <summary>
+/// Automatically attaches the entity to the wall when it appears, or removes it
+/// </summary>
+[RegisterComponent, Access(typeof(CP14WallmountSystem))]
+public sealed partial class CP14WallmountComponent : Component
+{
+}

--- a/Content.Shared/_CP14/Wallmount/CP14WallmountSystem.cs
+++ b/Content.Shared/_CP14/Wallmount/CP14WallmountSystem.cs
@@ -1,4 +1,3 @@
-using System.Numerics;
 using Content.Shared.Tag;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
@@ -12,7 +11,7 @@ public sealed class CP14WallmountSystem : EntitySystem
     [Dependency] private readonly SharedMapSystem _map = default!;
     [Dependency] private readonly TagSystem _tag = default!;
 
-    private static readonly ProtoId<TagPrototype>[] WallTags = {"Wall", "Window"};
+    public static readonly ProtoId<TagPrototype>[] WallTags = {"Wall", "Window"};
 
     public override void Initialize()
     {

--- a/Content.Shared/_CP14/Wallmount/CP14WallmountSystem.cs
+++ b/Content.Shared/_CP14/Wallmount/CP14WallmountSystem.cs
@@ -1,0 +1,48 @@
+using System.Numerics;
+using Content.Shared.Tag;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._CP14.Wallmount;
+
+public sealed class CP14WallmountSystem : EntitySystem
+{
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly SharedMapSystem _map = default!;
+    [Dependency] private readonly TagSystem _tag = default!;
+
+    private static readonly ProtoId<TagPrototype>[] WallTags = {"Wall", "Window"};
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<CP14WallmountComponent, MapInitEvent>(OnMapInit);
+    }
+
+    private void OnMapInit(Entity<CP14WallmountComponent> ent, ref MapInitEvent args)
+    {
+        var grid = Transform(ent).GridUid;
+        if (grid == null || !TryComp<MapGridComponent>(grid, out var gridComp))
+            return;
+
+        //Try found a wall in neighbour tile
+        var offset = Transform(ent).LocalRotation.ToWorldVec();
+        var targetPos = new EntityCoordinates(grid.Value,Transform(ent).LocalPosition - offset);
+        var anchored = _map.GetAnchoredEntities(grid.Value, gridComp, targetPos);
+
+        bool hasParent = false;
+        foreach (var entt in anchored)
+        {
+            if (!_tag.HasAnyTag(entt, WallTags))
+                continue;
+
+            _transform.SetParent(ent, entt);
+            hasParent = true;
+            break;
+        }
+        if (!hasParent)
+            QueueDel(ent);
+    }
+}

--- a/Resources/Locale/en-US/_CP14/construction/wall-required.ftl
+++ b/Resources/Locale/en-US/_CP14/construction/wall-required.ftl
@@ -1,0 +1,1 @@
+cp14-construction-step-condition-wall-required = Wall required.

--- a/Resources/Locale/ru-RU/_CP14/construction/wall-required.ftl
+++ b/Resources/Locale/ru-RU/_CP14/construction/wall-required.ftl
@@ -1,0 +1,1 @@
+cp14-construction-step-condition-wall-required = Необходима опора.

--- a/Resources/Prototypes/Tiles/space.yml
+++ b/Resources/Prototypes/Tiles/space.yml
@@ -1,4 +1,5 @@
 - type: tile
+  editorHidden: false
   id: Space
   name: tiles-space
   friction: 0

--- a/Resources/Prototypes/_CP14/Entities/Structures/Furniture/wallmount.yml
+++ b/Resources/Prototypes/_CP14/Entities/Structures/Furniture/wallmount.yml
@@ -10,6 +10,7 @@
   - type: InteractionOutline
   - type: Sprite
     drawdepth: Mobs
+  - type: CP14Wallmount
 
 - type: entity
   id: CP14WallmountTorch

--- a/Resources/Prototypes/_CP14/Recipes/Construction/furniture.yml
+++ b/Resources/Prototypes/_CP14/Recipes/Construction/furniture.yml
@@ -62,14 +62,15 @@
   targetNode: CP14WallmountTorch
   category: construction-category-furniture
   icon:
-    sprite: _CP14/Structures/Wallmount/wallmount_32icon.rsi
-    state: torch
+    sprite: _CP14/Structures/Furniture/wallmount_torch.rsi
+    state: fire
   objectType: Structure
   placementMode: SnapgridCenter
   canBuildInImpassable: false
   canRotate: true
   conditions:
     - !type:TileNotBlocked
+    - !type:CP14WallRequired
 
 - type: construction
   crystallPunkAllowed: true


### PR DESCRIPTION
wallmount objects are now automatically parenting to the wall, destroyed with it, and move with it. 

Added a new building condition to allow wallmounts to be built only at the wall\window

fix torch construction preview