### PR TITLE
[Fix] Do not ignite zero coordinates because of items inside containers.

### DIFF
--- a/Content.Server/_CP14/Temperature/CP14FireSpreadSystem.cs
+++ b/Content.Server/_CP14/Temperature/CP14FireSpreadSystem.cs
@@ -98,6 +98,10 @@ public sealed partial class CP14FireSpreadSystem : EntitySystem
         if (!TryComp<MapGridComponent>(xform.GridUid, out var grid))
             return;
 
+        // Ignore items inside containers
+        if (!HasComp<MapGridComponent>(xform.ParentUid))
+            return;
+
         var localPos = xform.Coordinates.Position;
         var tileRefs = _mapSystem.GetLocalTilesIntersecting(grid.Owner,
                 grid,


### PR DESCRIPTION
## About the PR
Fixes #277 by ignoring the ignition caused by items inside container (in that issue there were logs inside bonfire).

## Why / Balance
Items inside containers have zero coordinates, so we shouldn't use them in the fire spread system. Maybe we should somehow get map coordinates of the item.

Fixes #277