### PR TITLE
stuttering on bloodloss and electricity damage

### DIFF
--- a/Content.Server/Speech/EntitySystems/StutteringSystem.cs
+++ b/Content.Server/Speech/EntitySystems/StutteringSystem.cs
@@ -13,7 +13,7 @@ namespace Content.Server.Speech.EntitySystems
         [Dependency] private readonly IRobustRandom _random = default!;
 
         // Regex of characters to stutter.
-        private static readonly Regex Stutter = new(@"[b-df-hj-np-tv-wxyz]",
+        private static readonly Regex Stutter = new(@"[b-df-hj-np-tv-wxyz-б-вд-к-лмн-прст]", // CP14 Change Corvax-Localization
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public override void Initialize()


### PR DESCRIPTION
## About the PR
CHANGE WIZARD's CODE. Stuttering on bloodloss for russian localization, made as it was on Corvax.
Though, better to be fixed on wizard's side by moving this regex into .ftl file
Fixes https://github.com/crystallpunk-14/crystall-punk-14/issues/291
<!-- What did you change in this PR? -->
<!-- Что вы изменили в своем пулл реквесте? -->

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
<!-- Зачем нужно это изменение? Прикрепите любые обсуждения или проблемы здесь. Опишите, как это повлияет на текущий баланс игры. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->
<!-- 
Пулл реквесты, которые несут за собой игровые изменения (добавления одежды, предметов и так далее) требуют чтобы вы прикрепили скриншоты или видеоролики, демонстрирующие эти изменения.
Небольшие исправления не считаются.
-->
![bloodloss accent 2 2024-07-03](https://github.com/crystallpunk-14/crystall-punk-14/assets/56667933/070e5130-fcf9-4f45-9979-cff1e0077d6f)
![bloodloss accent 2024-07-03](https://github.com/crystallpunk-14/crystall-punk-14/assets/56667933/4534b065-41b6-4eb9-87b1-422f461ee702)
