### PR TITLE
Selfdamage for melee (#85)

### DIFF
--- a/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server._CP14.MeleeWeapon;
+using Content.Server._CP14.MeleeWeapon.Components;
 using Content.Server.Administration.Logs;
 using Content.Server.Damage.Components;
 using Content.Server.Weapons.Ranged.Systems;

--- a/Content.Server/_CP14/MeleeWeapon/Components/CP14MeleeSelfDamageComponent.cs
+++ b/Content.Server/_CP14/MeleeWeapon/Components/CP14MeleeSelfDamageComponent.cs
@@ -1,0 +1,10 @@
+using Content.Shared.Damage;
+
+namespace Content.Server._CP14.MeleeWeapon.Components;
+
+[RegisterComponent]
+public sealed partial class CP14MeleeSelfDamageComponent : Component
+{
+    [DataField(required: true)]
+    public DamageSpecifier DamageToSelf;
+}

--- a/Content.Server/_CP14/MeleeWeapon/Components/CP14SharpenedComponent.cs
+++ b/Content.Server/_CP14/MeleeWeapon/Components/CP14SharpenedComponent.cs
@@ -1,5 +1,7 @@
 
-namespace Content.Server._CP14.MeleeWeapon;
+using Content.Server._CP14.MeleeWeapon.EntitySystems;
+
+namespace Content.Server._CP14.MeleeWeapon.Components;
 
 /// <summary>
 /// allows the object to become blunt with use

--- a/Content.Server/_CP14/MeleeWeapon/Components/CP14SharpeningStoneComponent.cs
+++ b/Content.Server/_CP14/MeleeWeapon/Components/CP14SharpeningStoneComponent.cs
@@ -1,7 +1,8 @@
-﻿using Content.Shared.Damage;
+﻿using Content.Server._CP14.MeleeWeapon.EntitySystems;
+using Content.Shared.Damage;
 using Robust.Shared.Audio;
 
-namespace Content.Server._CP14.MeleeWeapon;
+namespace Content.Server._CP14.MeleeWeapon.Components;
 
 /// <summary>
 /// component allows you to sharpen objects by restoring their damage.

--- a/Content.Server/_CP14/MeleeWeapon/EntitySystems/CP14MeleeSelfDamageSystem.cs
+++ b/Content.Server/_CP14/MeleeWeapon/EntitySystems/CP14MeleeSelfDamageSystem.cs
@@ -1,0 +1,24 @@
+using Content.Server._CP14.MeleeWeapon.Components;
+using Content.Shared.Damage;
+using Content.Shared.Weapons.Melee.Events;
+
+namespace Content.Server._CP14.MeleeWeapon.EntitySystems;
+
+public sealed class CP14MeleeSelfDamageSystem : EntitySystem
+{
+    [Dependency] private readonly DamageableSystem _damageable = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<CP14MeleeSelfDamageComponent, MeleeHitEvent>(OnMeleeHit);
+    }
+
+    private void OnMeleeHit(Entity<CP14MeleeSelfDamageComponent> ent, ref MeleeHitEvent args)
+    {
+        if (!args.IsHit)
+            return;
+        if (args.HitEntities.Count == 0)
+            return;
+        _damageable.TryChangeDamage(ent, ent.Comp.DamageToSelf);
+    }
+}

--- a/Content.Server/_CP14/MeleeWeapon/EntitySystems/CP14SharpeningSystem.cs
+++ b/Content.Server/_CP14/MeleeWeapon/EntitySystems/CP14SharpeningSystem.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Server._CP14.MeleeWeapon.Components;
 using Content.Shared.Damage;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
@@ -8,7 +9,7 @@ using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Wieldable;
 using Robust.Shared.Audio.Systems;
 
-namespace Content.Server._CP14.MeleeWeapon;
+namespace Content.Server._CP14.MeleeWeapon.EntitySystems;
 
 public sealed class CP14SharpeningSystem : EntitySystem
 {

--- a/Content.Server/_CP14/Skills/CP14SkillSystem.cs
+++ b/Content.Server/_CP14/Skills/CP14SkillSystem.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using Content.Server._CP14.Alchemy;
 using Content.Server._CP14.MeleeWeapon;
+using Content.Server._CP14.MeleeWeapon.EntitySystems;
 using Content.Server.Popups;
 using Content.Shared._CP14.Skills;
 using Content.Shared._CP14.Skills.Components;

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/Melee/base.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/Melee/base.yml
@@ -21,7 +21,7 @@
 - type: entity
   id: CP14BaseWeaponThrowable
   abstract: true
-  components: 
+  components:
   - type: LandAtCursor
   - type: DamageOtherOnHit
     damage:
@@ -56,7 +56,7 @@
 - type: entity
   id: CP14BaseWeaponShort
   abstract: true
-  components: 
+  components:
   - type: MeleeWeapon
     range: 1.0 # 1.5 standart
     cPAnimationOffset: -0.75
@@ -89,3 +89,12 @@
           collection: MetalBreak
       - !type:DoActsBehavior
         acts: ["Destruction"]
+
+- type: entity
+  id: CP14BaseWeaponSelfDamage
+  abstract: true
+  components:
+  - type: CP14MeleeSelfDamage
+    damageToSelf:
+      types:
+        Blunt: 1 # 50 hits

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/Melee/base.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/Melee/base.yml
@@ -97,4 +97,4 @@
   - type: CP14MeleeSelfDamage
     damageToSelf:
       types:
-        Blunt: 1 # 50 hits
+        Blunt: 0.5 # 100 hits

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/Melee/battleHammer.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/Melee/battleHammer.yml
@@ -3,6 +3,7 @@
   parent:
   - BaseItem
   - CP14BaseWeaponDestructible
+  - CP14BaseWeaponSelfDamage
   name: battle hammer
   description: A big heavy hammer! Bruh! #TODO
   components:

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/Melee/lightHammer.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/Melee/lightHammer.yml
@@ -1,11 +1,12 @@
 - type: entity
   id: CP14BaseLightHammer
-  parent: 
+  parent:
   - BaseItem
   - CP14BaseWeaponDestructible
   - CP14BaseWeaponThrowable
   - CP14BaseWeaponLight
   - CP14BaseWeaponShort
+  - CP14BaseWeaponSelfDamage
   name: light hammer
   description: A small hammer. Good for carpentry work as well as for cracking skulls.
   components:

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/Melee/mace.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/Melee/mace.yml
@@ -1,9 +1,10 @@
 - type: entity
   id: CP14BaseMace
-  parent: 
+  parent:
   - BaseItem
   - CP14BaseWeaponDestructible
   - CP14BaseWeaponThrowable
+  - CP14BaseWeaponSelfDamage
   name: mace
   description: A heavy piece of metal on a long stick. What could be simpler than that?
   components:


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
<!-- Что вы изменили в своем пулл реквесте? -->
Content.Server/MeleeWeapon разделен на две подпапки: `Component` и `EntitySystems`
Теперь оружию с компонентом `CP14MeleeSelfDamage` наносится урон. 
Добавлен прототип `CP14BaseWeaponSelfDamage` для оружием урона по самому себе от ударов.
По умолчанию, оружия хватает на 50 ударов.

## Why / Balance
Решает #85

## Media

https://github.com/user-attachments/assets/a4925cc7-4278-44fd-b3cb-fc0549608eea

