### PR TITLE
Remove "bruh" desc

### DIFF
--- a/Resources/Locale/ru-RU/_CP14/_PROTO/entities/entities.ftl
+++ b/Resources/Locale/ru-RU/_CP14/_PROTO/entities/entities.ftl
@@ -399,7 +399,7 @@ ent-CP14BaseSharpeningStone = точильный камень
     .desc = Позволит заточить притупленное оружие. Если перестараться, вы вполне можете сточить оружие полностью.
 
 ent-CP14BaseBattleHammer = боевой молот
-    .desc = A big heavy hammer! Bruh!
+    .desc = Большой тяжелый молот. Лучше вам не стоять у него на пути!
 
 ent-CP14BaseBattleStaff = боевой посох
     .desc = Нет оружия проще и эффективнее, чем длинная и тяжелая палка!
@@ -604,7 +604,7 @@ ent-CP14CrystalDiamondsBig = { ent-CP14CrystalBase }
     .suffix = White, Big
 
 ent-CP14FloorWater = вода
-    .desc = Брух
+    .desc = Впадина с обычной водой. Достаточна чиста для употребления.
 
 ent-CP14HighBush = высокий куст
     .desc = Высокие и густые заросли. Возможно кто-то наблюдает за тобой из них.
@@ -846,7 +846,7 @@ ent-CP14WallStone = камень
     .desc = Природная стена из цельного камня. В ней ощущается холод пещеры.
 
 ent-CP14WallDirt = земляной холм
-    .desc = bruh
+    .desc = Высокая куча земли. Можно ли построить из нее дом?
 
 ent-CP14WallStoneGoldOre = { ent-CP14WallStone }
     .desc = A solid stone natural wall. You see the tantalizing particles of gold in it.

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/Melee/battleHammer.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/Melee/battleHammer.yml
@@ -5,7 +5,7 @@
   - CP14BaseWeaponDestructible
   - CP14BaseWeaponSelfDamage
   name: battle hammer
-  description: A big heavy hammer! Bruh! #TODO
+  description: A big heavy hammer. You better not get in his way!
   components:
   - type: Sprite
     sprite: _CP14/Objects/Weapons/Melee/BattleHammer/battleHammer.rsi

--- a/Resources/Prototypes/_CP14/Entities/Structures/Flora/floorWater.yml
+++ b/Resources/Prototypes/_CP14/Entities/Structures/Flora/floorWater.yml
@@ -2,7 +2,7 @@
   parent: BaseStructure
   id: CP14FloorWater
   name: water
-  description: Bruh
+  description: A trough of plain water. Clean enough for consumption
   placement:
     mode: SnapgridCenter
     snap:

--- a/Resources/Prototypes/_CP14/Entities/Structures/Walls/natural.yml
+++ b/Resources/Prototypes/_CP14/Entities/Structures/Walls/natural.yml
@@ -36,7 +36,7 @@
   id: CP14WallDirt
   name: earth cliffs
   parent: CP14BaseWall
-  description: bruh #TODO
+  description: A tall pile of dirt. Can a house be built from it?
   components:
   - type: Sprite
     sprite: _CP14/Structures/Walls/Natural/dirt_wall.rsi

--- a/Resources/Prototypes/_CP14/Recipes/Construction/walls.yml
+++ b/Resources/Prototypes/_CP14/Recipes/Construction/walls.yml
@@ -37,7 +37,7 @@
 - type: construction
   crystallPunkAllowed: true
   name: Earth cliffs
-  description: bruh #TODO
+  description: A tall pile of dirt. Can a house be built from it?
   id: CP14WallDirt
   graph: CP14WallDirt
   startNode: start


### PR DESCRIPTION
## About the PR
Removed “bruh” descriptions from the entity and localization file
Убраны "брух" описания из энтити и файла локализации

## Why / Balance
[issue resolution](https://github.com/crystallpunk-14/crystall-punk-14/issues/207)

## Media
![image](https://github.com/user-attachments/assets/62b6c16d-952b-45a6-898b-e03f148365f5)
