### PR TITLE
Add throwing tomatoes and fix

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/produce.yml
@@ -273,10 +273,6 @@
         solution: food
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-  - type: Tag
-    tags:
-    - Fruit
-    - Vegetable
   - type: Extractable
     grindableSolutionName: food
     juiceSolution:

--- a/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/produce.yml
@@ -277,11 +277,6 @@
     tags:
     - Fruit
     - Vegetable
-  - type: FoodSequenceElement
-    entries:
-      Skewer: TomatoSkewer
-      Burger: Tomato
-      Taco: Tomato
   - type: Extractable
     grindableSolutionName: food
     juiceSolution:

--- a/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/produce.yml
@@ -77,7 +77,7 @@
   parent: FoodInjectableBase
   categories: [ ForkFiltered ]
   name: pumpkin
-  description: Big, cool pumpkin. 
+  description: Big, cool pumpkin.
   components:
   - type: Item
     size: Normal
@@ -116,7 +116,7 @@
   categories: [ ForkFiltered ]
   name: pumpkin slice
   description: Pumpkin! # TODO
-  components: 
+  components:
   - type: Item
     size: Tiny
   - type: FlavorProfile
@@ -224,7 +224,7 @@
 
 - type: entity
   id: CP14FoodTomatoes
-  parent: FoodInjectableBase
+  parent: [FoodInjectableBase, ItemHeftyBase]
   categories: [ ForkFiltered ]
   name: tomatoes
   description: A red, juicy tomato. You just want to throw it in someone's face!
@@ -248,16 +248,53 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 8
+        maxVol: 12
         reagents:
         - ReagentId: Nutriment
           Quantity: 3
         - ReagentId: Vitamin
           Quantity: 3
+        - ReagentId: JuiceTomato
+          Quantity: 6
   - type: SliceableFood
     count: 3
     sliceTime: 1
     slice: CP14FoodTomatoesSlice
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 1
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: desecration
+      - !type:SpillBehavior
+        solution: food
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: Tag
+    tags:
+    - Fruit
+    - Vegetable
+  - type: FoodSequenceElement
+    entries:
+      Skewer: TomatoSkewer
+      Burger: Tomato
+      Taco: Tomato
+  - type: Extractable
+    grindableSolutionName: food
+    juiceSolution:
+      reagents:
+      - ReagentId: JuiceTomato
+        Quantity: 10
+  - type: Damageable
+    damageContainer: Biological
+  - type: DamageOnHighSpeedImpact
+    minimumSpeed: 0.1
+    damage:
+      types:
+        Blunt: 1
 
 - type: entity
   id: CP14FoodTomatoesSlice
@@ -265,7 +302,7 @@
   categories: [ ForkFiltered ]
   name: tomato slice
   description: Thin red tomato slice. It's no longer as nice to throw at people as whole tomatoes.
-  components: 
+  components:
   - type: Item
     size: Tiny
   - type: FlavorProfile


### PR DESCRIPTION
### {RU}

## About the PR
`ItemHeftyBase` - Новый parrent для того чтобы работало корректно бросание помидора, вместимость жидкостей изменена из `8 -> 12` поскольку нужно место и для помидорного сока, `Destructible` чтобы при броске помидора он разваливался, ну то-есть бился. `Tag` - Нужно просто для удобного поиска по тэгам в спавне.

`  - type: FoodSequenceElement
    entries:
      Skewer: TomatoSkewer
      Burger: Tomato
      Taco: Tomato`

`FoodSequenceElement` был добавлен просто для готовки или для чего-то другого. Впрочем это есть в Space Station 14 оригинальной, ну пусть и будет в этом коде. Не мешает. `Extractable` можно извлечь сок из помидора, как не странно 10 унций. `DamageOnHighSpeedImpact` для получения урона в 1 единицу. `Damageable` для звука разбития помидора.

## Why / Balance
Помидоры теперь как и в реальной жизни, то-есть могут разбиваться об пол либо об стену, даже если нацелится на человека курсором можно его опозорить на публике. Наносит 1 урон blut, урон не отображается на мишени. Его можно кушать, утоляет немного жажду и немного голода.

fix #514 
## Media
https://github.com/user-attachments/assets/4549ee0d-0fca-484f-bff7-3be3374b9e9f

