### PR TITLE
Remove demiplan fun

### DIFF
--- a/Content.Server/_CP14/Demiplane/CP14DemiplanSystem.Generation.cs
+++ b/Content.Server/_CP14/Demiplane/CP14DemiplanSystem.Generation.cs
@@ -55,7 +55,7 @@ public sealed partial class CP14DemiplaneSystem
             return msg;
 
         msg.AddMarkupOrThrow(
-            indexedLocation.Name is not null && _random.Prob(indexedLocation.ExamineProb)
+            indexedLocation.Name is not null/* && _random.Prob(indexedLocation.ExamineProb)*/
                 ? Loc.GetString("cp14-demiplane-examine-title", ("location", Loc.GetString(indexedLocation.Name)))
                 : Loc.GetString("cp14-demiplane-examine-title-unknown"));
 
@@ -65,8 +65,8 @@ public sealed partial class CP14DemiplaneSystem
             if (!_proto.TryIndex(modifier, out var indexedModifier))
                 continue;
 
-            if (!_random.Prob(indexedModifier.ExamineProb))
-                continue;
+            //if (!_random.Prob(indexedModifier.ExamineProb)) //temp disable
+            //    continue;
 
             if (indexedModifier.Name is null)
                 continue;

--- a/Resources/Prototypes/_CP14/Procedural/Demiplane/Modifiers/test.yml
+++ b/Resources/Prototypes/_CP14/Procedural/Demiplane/Modifiers/test.yml
@@ -286,17 +286,28 @@
       minGroupSize: 1
       maxGroupSize: 2
 
+#- type: cp14DemiplaneModifier
+#  id: Ruins
+#  name: cp14-modifier-ruins
+#  reward: 0.35
+#  generationWeight: 2
+#  layers:
+#    - !type:OreDunGen
+#      entity: ##CP14DemiplanRuinsRoomSpawner
+#      count: 5
+#      minGroupSize: 1
+#      maxGroupSize: 1
+
 - type: cp14DemiplaneModifier
-  id: Ruins
-  name: cp14-modifier-ruins
+  id: Loot
   reward: 0.35
   generationWeight: 2
   layers:
     - !type:OreDunGen
-      entity: CP14DemiplanRuinsRoomSpawner
-      count: 5
+      entity: CP14SpawnerExpeditionLootCommon
+      count: 15
       minGroupSize: 1
-      maxGroupSize: 1
+      maxGroupSize: 3
 
 - type: cp14DemiplaneModifier
   id: EnemyXeno

--- a/Resources/Prototypes/_CP14/Procedural/Demiplane/exterier_room.yml
+++ b/Resources/Prototypes/_CP14/Procedural/Demiplane/exterier_room.yml
@@ -1,17 +1,17 @@
 - type: Tag
   id: CP14DemiplanRuins
 
-- type: entity
-  id: CP14DemiplanRuinsRoomSpawner
-  categories: [ ForkFiltered ]
-  parent: BaseRoomMarker
-  name: Demiplan ruins room spawner
-  components:
-  - type: RoomFill
-    clearExisting: true
-    roomWhitelist:
-      tags:
-      - CP14DemiplanRuins
+#- type: entity
+#  id: CP14DemiplanRuinsRoomSpawner
+#  categories: [ ForkFiltered ]
+#  parent: BaseRoomMarker
+#  name: Demiplan ruins room spawner
+#  components:
+#  - type: RoomFill
+#    clearExisting: true
+#    roomWhitelist:
+#      tags:
+#      - CP14DemiplanRuins
 
 # 7x7
 - type: dungeonRoom

--- a/Resources/Prototypes/_CP14/Procedural/Demiplane/required_layers.yml
+++ b/Resources/Prototypes/_CP14/Procedural/Demiplane/required_layers.yml
@@ -2,10 +2,10 @@
   id: DemiplaneConnections
   layers:
     - !type:OreDunGen
-      entity: CP14DemiplanEnterRoomMarker
+      entity: CP14DemiplaneEntryPointMarker
       count: 1
-      minGroupSize: 1
-      maxGroupSize: 1
+      minGroupSize: 4
+      maxGroupSize: 4
     - !type:OreDunGen
       entity: CP14DemiplanePassway
       count: 2


### PR DESCRIPTION
## About the PR
- disable room spawning (and starting room) in demiplanes, because its cause check failing
- disable demiplane examination randomness, because its broken. All modifiers visibility for now 