### PR TITLE
Update SpellStorage

### DIFF
--- a/Content.Shared/_CP14/MagicSpellStorage/CP14SpellStorageComponent.cs
+++ b/Content.Shared/_CP14/MagicSpellStorage/CP14SpellStorageComponent.cs
@@ -25,4 +25,28 @@ public sealed partial class CP14SpellStorageComponent : Component
     /// </summary>
     [DataField]
     public bool CanUseCasterMana = true;
+
+    /// <summary>
+    /// Maximum number of spells in storage.
+    /// </summary>
+    [DataField]
+    public int MaxSpellsCount = 1;
+
+    /// <summary>
+    /// allows you to getting spells from another storage.
+    /// </summary>
+    [DataField]
+    public bool AllowSpellsGetting = false;
+
+    /// <summary>
+    /// allows you to transfer spells to another storage. It won't work if AllowSpellsGetting is True.
+    /// </summary>
+    [DataField]
+    public bool AllowSpellsTransfering = false;
+
+    /// <summary>
+    /// It work if AllowSpellsTransfering is True. Delete storage entity after interact.
+    /// </summary>
+    [DataField]
+    public bool DeleteStorageAfterInteract = false;
 }

--- a/Resources/Locale/en-US/_CP14/spells-storage/spells-storage.ftl
+++ b/Resources/Locale/en-US/_CP14/spells-storage/spells-storage.ftl
@@ -1,0 +1,2 @@
+cp14-spells-storage-cant-transfer = You can't transfer spells from this item.
+cp14-spells-storage-cant-get-spells = This item cannot get new spells.

--- a/Resources/Locale/ru-RU/_CP14/spells-storage/spells-storage.ftl
+++ b/Resources/Locale/ru-RU/_CP14/spells-storage/spells-storage.ftl
@@ -1,0 +1,2 @@
+cp14-spells-storage-cant-transfer = Нельзя переместить заклинания из данного предмета.
+cp14-spells-storage-cant-get-spells = Этот предмет не может принять новые заклинания.

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/Magic/twoHandedStaffs.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/Magic/twoHandedStaffs.yml
@@ -23,7 +23,7 @@
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
-      types: 
+      types:
         Blunt: 6
   - type: MeleeWeapon
     angle: 100
@@ -42,6 +42,7 @@
   - type: CP14MagicAttuningItem
   - type: CP14SpellStorageAccessHolding
   - type: CP14SpellStorage
+    maxSpellsCount: 4
     spells:
     - CP14ActionSpellCureWounds
     - CP14ActionSpellCureBurn


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
<!-- Что вы изменили в своем пулл реквесте? -->
1) Теперь можно указывать максимальное количество заклинаний внутри хранилища.
2) Можно перенести заклинания из одного хранилища в другое.

Эти изменения позволят сделать посохи более настраиваемыми.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
<!-- Зачем нужно это изменение? Прикрепите любые обсуждения или проблемы здесь. Опишите, как это повлияет на текущий баланс игры. -->

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->
<!--
Пулл реквесты, которые несут за собой игровые изменения (добавления одежды, предметов и так далее) требуют чтобы вы прикрепили скриншоты или видеоролики, демонстрирующие эти изменения.
Небольшие исправления не считаются.
-->
