### PR TITLE
Demiplane Crystal

### DIFF
--- a/Content.Server/_CP14/Demiplane/CP14DemiplanSystem.Generation.cs
+++ b/Content.Server/_CP14/Demiplane/CP14DemiplanSystem.Generation.cs
@@ -26,6 +26,7 @@ public sealed partial class CP14DemiplaneSystem
     private const double JobMaxTime = 0.002;
 
     [Dependency] private readonly ExamineSystemShared _examine = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
 
     private void InitGeneration()
     {
@@ -140,6 +141,23 @@ public sealed partial class CP14DemiplaneSystem
     {
         if (generator.Comp.Location is null)
             return;
+
+        var curTime = _timing.CurTime;
+
+        if (curTime < generator.Comp.LastUseTime + generator.Comp.UseDelay)
+            return;
+
+        generator.Comp.LastUseTime = curTime;
+
+        if (generator.Comp.NeedDemiplaneCrystal)
+        {
+            var demiplaneCrystals = _lookup.GetEntitiesInRange<CP14DemiplaneCrystalComponent>(Transform(generator).Coordinates, generator.Comp.DemiplaneCrystalRange);
+            if (demiplaneCrystals.Count == 0)
+            {
+                return;
+            }
+
+        }
 
         //We cant open demiplan in another demiplan or if parent is not Map
         if (HasComp<CP14DemiplaneComponent>(Transform(generator).MapUid) || !HasComp<MapGridComponent>(_transform.GetParentUid(args.User)))

--- a/Content.Server/_CP14/Demiplane/Components/CP14DemiplaneCrystalComponent.cs
+++ b/Content.Server/_CP14/Demiplane/Components/CP14DemiplaneCrystalComponent.cs
@@ -1,0 +1,6 @@
+namespace Content.Server._CP14.Demiplane.Components;
+
+[RegisterComponent, Access(typeof(CP14DemiplaneSystem))]
+public sealed partial class CP14DemiplaneCrystalComponent : Component
+{
+}

--- a/Content.Server/_CP14/Demiplane/Components/CP14DemiplaneGeneratorDataComponent.cs
+++ b/Content.Server/_CP14/Demiplane/Components/CP14DemiplaneGeneratorDataComponent.cs
@@ -23,4 +23,16 @@ public sealed partial class CP14DemiplaneGeneratorDataComponent : Component
 
     [DataField(required: true)]
     public Dictionary<ProtoId<CP14DemiplaneModifierCategoryPrototype>, float> Limits;
+
+    [DataField]
+    public bool NeedDemiplaneCrystal = true;
+
+    [DataField]
+    public float DemiplaneCrystalRange = 15f;
+
+    [DataField]
+    public TimeSpan UseDelay = TimeSpan.FromSeconds(1.0);
+
+    [DataField]
+    public TimeSpan LastUseTime = TimeSpan.Zero;
 }


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
<!-- Что вы изменили в своем пулл реквесте? -->
ПР Добавляет Кристалл Демиплана. Теперь Демипланы можно открыть только в радиусе 15 тайлов от кристалла.
todo:
- [ ] Добавить попапы
- [ ] Сделать прототип Кристалла
  - [ ] Спрайт Кристалла

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
<!-- Зачем нужно это изменение? Прикрепите любые обсуждения или проблемы здесь. Опишите, как это повлияет на текущий баланс игры. -->

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->
<!--
Пулл реквесты, которые несут за собой игровые изменения (добавления одежды, предметов и так далее) требуют чтобы вы прикрепили скриншоты или видеоролики, демонстрирующие эти изменения.
Небольшие исправления не считаются.
-->
