### PR TITLE
Battle staff damage balance

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/Melee/battleStaff.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/Melee/battleStaff.yml
@@ -24,7 +24,7 @@
   - type: IncreaseDamageOnWield
     damage:
       types: 
-        Blunt: 8
+        Blunt: 4
   - type: MeleeWeapon
     angle: 100
     attackRate: 1.3
@@ -33,7 +33,7 @@
     wideAnimation: CP14WeaponArcSlash
     damage:
       types:
-        Blunt: 8
+        Blunt: 6
     soundHit:
       collection: MetalThud
     cPAnimationLength: 0.3


### PR DESCRIPTION
## About the PR

Reduced the damage of the battle staff for balance.
Уменьшил урон боевого посоха для баланса.

## Why / Balance

Потому что имба.