### PR TITLE
Apron containers

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Clothing/Cloak/Roles/alchemist.yml
+++ b/Resources/Prototypes/_CP14/Entities/Clothing/Cloak/Roles/alchemist.yml
@@ -1,5 +1,7 @@
 - type: entity
-  parent: CP14ClothingCloakBase
+  parent: 
+  - CP14ClothingCloakBase
+  - CP14ClothingBaseContainer
   id: CP14ClothingCloakAlchemist
   name: alchemist's cloak
   description: An expensive fabric that can withstand acid splashes - the standard for alchemist experts.
@@ -13,3 +15,11 @@
       coefficients:
         Heat: 0.9
         Caustic: 0.75
+  - type: Storage
+    maxItemSize: Tiny
+    defaultStorageOrientation: Vertical
+    grid:
+    - 0,0,1,1
+    whitelist:
+      tags:
+        - CP14Vial

--- a/Resources/Prototypes/_CP14/Entities/Clothing/Cloak/Roles/blacksmith.yml
+++ b/Resources/Prototypes/_CP14/Entities/Clothing/Cloak/Roles/blacksmith.yml
@@ -1,0 +1,28 @@
+- type: entity
+  parent: 
+  - CP14ClothingCloakBase
+  - CP14ClothingBaseContainer
+  id: CP14ClothingCloakBlacksmithArpon
+  name: blacksmith's apron
+  description: Loose leather strips, still actually being clothing. 
+  components:
+  - type: Sprite
+    sprite: _CP14/Clothing/Cloak/Roles/General/blacksmith_apron.rsi
+  - type: Clothing
+    sprite: _CP14/Clothing/Cloak/Roles/General/blacksmith_apron.rsi
+  - type: Armor
+    modifiers:
+      coefficients:
+        Heat: 0.95
+  - type: Storage
+    maxItemSize: Small
+    defaultStorageOrientation: Vertical
+    grid:
+    - 0,0,2,1
+    whitelist:
+      tags:
+        - Crayon
+        - CP14Lighter
+        - CP14Scissors
+        - CP14SharpeningStone
+        - CP14Nail

--- a/Resources/Prototypes/_CP14/Entities/Clothing/Cloak/sort_later.yml
+++ b/Resources/Prototypes/_CP14/Entities/Clothing/Cloak/sort_later.yml
@@ -2,19 +2,6 @@
   parent: 
   - CP14ClothingCloakBase
   - ClothingSlotBase
-  id: CP14ClothingCloakBlacksmithArpon
-  name: blacksmith's apron
-  description: Loose leather strips, still actually being clothing. 
-  components:
-  - type: Sprite
-    sprite: _CP14/Clothing/Cloak/Roles/General/blacksmith_apron.rsi
-  - type: Clothing
-    sprite: _CP14/Clothing/Cloak/Roles/General/blacksmith_apron.rsi
-
-- type: entity
-  parent: 
-  - CP14ClothingCloakBase
-  - ClothingSlotBase
   id: CP14ClothingCloakMaidArpon
   name: maid's apron
   description: Cleanliness, orderliness and obedience are the main traits of a good maid.

--- a/Resources/Prototypes/_CP14/Entities/Clothing/base.yml
+++ b/Resources/Prototypes/_CP14/Entities/Clothing/base.yml
@@ -1,0 +1,13 @@
+- type: entity
+  abstract: true
+  id: CP14ClothingBaseContainer
+  categories: [ ForkFiltered ]
+  components:
+  - type: ContainerContainer
+    containers:
+      storagebase: !type:Container
+        ents: []
+  - type: UserInterface
+    interfaces:
+      enum.StorageUiKey.Key:
+        type: StorageBoundUserInterface

--- a/Resources/Prototypes/_CP14/Entities/Objects/Materials/simple.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Materials/simple.yml
@@ -345,6 +345,9 @@
     slipSound:
       path: /Audio/Effects/weak_hit2.ogg
     launchForwardsMultiplier: 0
+  - type: Tag
+    tags:
+    - CP14Nail
 
 - type: entity
   id: CP14Nail20

--- a/Resources/Prototypes/_CP14/Entities/Objects/Specific/Alchemy/vials.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Specific/Alchemy/vials.yml
@@ -51,6 +51,9 @@
     maxTransferAmount: 10
     transferAmount: 1
     toggleState: 1 # draw
+  - type: Tag
+    tags:
+    - CP14Vial
 
 - type: entity
   parent: CP14BaseVial

--- a/Resources/Prototypes/_CP14/Entities/Objects/Tools/flint.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Tools/flint.yml
@@ -13,3 +13,6 @@
   - type: CP14DelayedIgnitionSource
     enabled: true
   # TODO: Damageable, Ignite attempt self damage, Ignite prob
+  - type: Tag
+    tags:
+    - CP14Lighter

--- a/Resources/Prototypes/_CP14/Entities/Objects/Tools/scissors.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Tools/scissors.yml
@@ -27,3 +27,6 @@
         Piercing: 7
     soundHit:
       path: "/Audio/Weapons/bladeslice.ogg"
+  - type: Tag
+    tags:
+    - CP14Scissors

--- a/Resources/Prototypes/_CP14/Entities/Objects/Tools/sharpening_stone.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Tools/sharpening_stone.yml
@@ -26,3 +26,6 @@
         acts: ["Destruction"]
   - type: CP14SharpeningStone
     sharpnessHeal: 0.1
+  - type: Tag
+    tags:
+    - CP14SharpeningStone

--- a/Resources/Prototypes/_CP14/tags.yml
+++ b/Resources/Prototypes/_CP14/tags.yml
@@ -111,3 +111,18 @@
 
 - type: Tag
   id: CP14AlchemicalHerbals
+
+- type: Tag
+  id: CP14Lighter
+
+- type: Tag
+  id: CP14Scissors
+
+- type: Tag
+  id: CP14SharpeningStone
+
+- type: Tag
+  id: CP14Nail
+
+- type: Tag
+  id: CP14Vial


### PR DESCRIPTION
## About the PR

Adds a small container to the blacksmith's apron and alchemist's cloak with a whitelist.
Добавляет небольшой контейнер в фартук кузнеца и плащ алхимика с белым листом.

## Why / Balance

Blacksmiths' aprons are useless and are only decorative in nature, it will now make sense for blacksmiths to wear them on the job. Space for several vials has been added to the alchemists' cloak, which seems authentic and useful.
Фартуки кузнецов бесполезны и имеют только декоративный характер, теперь в них будет смысл носить кузнецам на рабочем месте. В плащ алхимиков добавлено место для нескольких склянок, что кажется аутентичным и полезным.
