### PR TITLE
Size gauze

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Specific/Medical/healing.yml
@@ -7,7 +7,7 @@
   categories: [ ForkFiltered ]
   components:
   - type: Item
-    size: Normal
+    size: Small
   - type: Sprite
     sprite: _CP14/Objects/Specific/Medical/medical.rsi
     state: herbbandage_3
@@ -58,7 +58,7 @@
   categories: [ ForkFiltered ]
   components:
   - type: Item
-    size: Normal
+    size: Small
   - type: Sprite
     sprite: _CP14/Objects/Specific/Medical/medical.rsi
     state: bandage_3


### PR DESCRIPTION
## About the PR

Reduces the size of the gauze to a small gauze.
Уменьшает размеры марли до маленького.

## Why / Balance

Увеличение размера одновременно с уменьшением стака, сильно уменьшило полезность марли, особенно то, что оно теперь занимает много места в сумке и не помещается в корманы. Для удобства использования, уменьшил вместимость, чтобы оно составляло конкуренцию для магии.