### PR TITLE
The rabbit is also a pie

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Mobs/NPC/animals.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/NPC/animals.yml
@@ -68,7 +68,7 @@
   - type: Butcherable
     spawned:
     - id: CP14FoodMeatRabbit
-      amount: 2
+      amount: 4
   - type: Bloodstream
     bloodMaxVolume: 50
     bloodReagent: CP14BloodAnimal

--- a/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/meat.yml
@@ -448,17 +448,20 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 10
+        maxVol: 5
         reagents:
         - ReagentId: Nutriment
-          Quantity: 6
-        - ReagentId: UncookedAnimalProteins
           Quantity: 3
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 1.5
   - type: RandomSprite
     available:
       - random:
           rabbit_meat1: ""
           rabbit_meat2: ""
+  - type: Tag
+    tags:
+    - CP14RawMeatSlice
   - type: CP14TemperatureTransformation
     entries:
     - temperatureRange: 400, 500
@@ -478,12 +481,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 10
+        maxVol: 5
         reagents:
         - ReagentId: Nutriment
-          Quantity: 6
-        - ReagentId: Protein
           Quantity: 3
+        - ReagentId: Protein
+          Quantity: 1.5
   - type: RandomSprite
     available:
       - random:


### PR DESCRIPTION
## About the PR

Changed the balance of the rabbit meat and it can now be used to make a meat pie too.
Изменил баланс мяса кроллика, и теперь его тоже можно использовать для готовки мясного пирога.

## Why / Balance

Rabbits are plentiful and their meat can only be used to a limited extent. Now they can be used to make meat pies.
Кроликов много, а мясо их использовать можно лишь ограничено. Теперь их можноиспользовать для готовки мясных пирогов.
