### PR TITLE
Zombi pacified

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Mobs/Species/zombie.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/Species/zombie.yml
@@ -88,6 +88,7 @@
     - Electrocution
     - Stutter
     - TemporaryBlindness
+    - Pacified
   - type: RotationVisuals
     defaultRotation: 90
     horizontalRotation: 90


### PR DESCRIPTION
## About the PR

Now zombies can be pacifists.
Теперь зомби могут быть пацифистами.

## Why / Balance

Fix #947

## Media

![изображение](https://github.com/user-attachments/assets/b88dd0df-4ee0-4659-9a26-43cd007a4ffd)
