### PR TITLE
[Fix] CP14Syringe transfer amount fix

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Objects/Specific/Alchemy/tools.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Specific/Alchemy/tools.yml
@@ -79,7 +79,7 @@
   categories: [ ForkFiltered ]
   components:
   - type: Tag
-    tags: 
+    tags:
     - CP14Pestle
   - type: Item
     size: Tiny
@@ -250,6 +250,9 @@
         maxVol: 10
   - type: Injector
     injectOnly: false
+    transferAmount: 5
+    minTransferAmount: 5
+    maxTransferAmount: 10
     toggleState: Draw
   - type: ExaminableSolution
     solution: injector


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
<!-- Что вы изменили в своем пулл реквесте? -->
Максимальный обьем шприца для выбора теперь 10u, а не 15u.
Maximum syringe transfer amount is now 10u instead of 15u.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
<!-- Зачем нужно это изменение? Прикрепите любые обсуждения или проблемы здесь. Опишите, как это повлияет на текущий баланс игры. -->
Максимум шприца - 10u.
Maximum syringe volume is 10u.
## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->
<!--
Пулл реквесты, которые несут за собой игровые изменения (добавления одежды, предметов и так далее) требуют чтобы вы прикрепили скриншоты или видеоролики, демонстрирующие эти изменения.
Небольшие исправления не считаются.
-->
![image](https://github.com/user-attachments/assets/a65f0f1f-929e-4c89-95a5-be4bcbe65dd8)
