### PR TITLE
Minor Skill Tree rebalance

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Death/T1_resurrection.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Death/T1_resurrection.yml
@@ -61,6 +61,7 @@
   id: CP14RuneResurrection
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#328643"
@@ -77,6 +78,7 @@
   id: CP14ImpactEffectResurrection
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Dimension/T0_demiplane_infiltration.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Dimension/T0_demiplane_infiltration.yml
@@ -43,6 +43,7 @@
   id: CP14RuneDemiplaneInfiltration
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#5e427e"

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Dimension/T0_monolith_warp.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Dimension/T0_monolith_warp.yml
@@ -39,6 +39,7 @@
   suffix: Teleport to demiplane crystal
   name: pulsating demiplane rift
   description: This rift is gaining strength, and will trap all nearby creatures in a demiplane in a second!
+  save: false
   components:
   - type: Transform
     anchored: True

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Dimension/T1_shadow_grab.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Dimension/T1_shadow_grab.yml
@@ -44,6 +44,7 @@
   id: CP14ImpactEffectShadowGrab
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Dimension/T2_shadow_step.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Dimension/T2_shadow_step.yml
@@ -37,6 +37,7 @@
   id: CP14ImpactEffectShadowStep
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Earth/MOB_subterranean_leap.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Earth/MOB_subterranean_leap.yml
@@ -39,6 +39,7 @@
   id: CP14ImpactEffectDigging
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     sprite: _CP14/Effects/material_splash.rsi

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Earth/T1_earth_wall.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Earth/T1_earth_wall.yml
@@ -39,6 +39,7 @@
   id: CP14RuneEarthWall
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#8f6a2b"
@@ -55,6 +56,7 @@
   id: CP14ImpactEffectEarthWall
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     layers:
@@ -65,6 +67,7 @@
 - type: entity
   id: CP14WallSpawnEarthWall
   categories: [ HideSpawnMenu ]
+  save: false
   placement:
     mode: SnapgridCenter
   components:

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/T0_flame_creation.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/T0_flame_creation.yml
@@ -37,6 +37,7 @@
   id: CP14RuneFlameCreation
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#eea911"
@@ -50,6 +51,7 @@
   id: CP14ImpactEffectFlameCreation
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/T0_hell_ballade.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/T0_hell_ballade.yml
@@ -34,6 +34,7 @@
 - type: entity
   id: CP14AreaEntityEffectHellBallade
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: TimedDespawn
     lifetime: 1.6
@@ -60,6 +61,7 @@
   id: CP14ImpactEffectHellBallade
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     sprite: _CP14/Effects/music.rsi
@@ -72,6 +74,7 @@
   id: CP14RuneHellBallade
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#eea911"

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/T0_tiefling_inner_fire.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/T0_tiefling_inner_fire.yml
@@ -42,6 +42,7 @@
   id: CP14ImpactEffectTieflingRevenge
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     layers:
@@ -53,6 +54,7 @@
   id: CP14RuneTieflingRevenge
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#eea911"

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/T1_fire_rune.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/T1_fire_rune.yml
@@ -37,6 +37,7 @@
   id: CP14TelegraphyFireRune
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#eea911"
@@ -56,6 +57,7 @@
   id: CP14AreaEntityEffectFireRune
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#eea911"

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/T1_fireball.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/T1_fireball.yml
@@ -43,6 +43,7 @@
   id: CP14RuneFireball
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#eea911"
@@ -59,6 +60,7 @@
   id: CP14ImpactEffectFireball
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     layers:
@@ -69,7 +71,7 @@
 - type: entity
   id: CP14Fireball
   parent: BulletRocket
-  name: artificial flame
+  name: fireball
   categories: [ HideSpawnMenu ]
   components:
   - type: PointLight

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/T0_cure_heat.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/T0_cure_heat.yml
@@ -54,6 +54,7 @@
   id: CP14RuneCureBurn
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#328643"
@@ -70,6 +71,7 @@
   id: CP14ImpactEffectCureBurn
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/T0_cure_poison.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/T0_cure_poison.yml
@@ -57,6 +57,7 @@
   id: CP14RuneBloodPurification
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#328643"
@@ -73,6 +74,7 @@
   id: CP14ImpactEffectBloodPurification
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/T0_cure_wounds.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/T0_cure_wounds.yml
@@ -54,6 +54,7 @@
   id: CP14RuneCureWounds
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#328643"
@@ -67,6 +68,7 @@
   id: CP14ImpactEffectCureWounds
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/T0_heal_ballade.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/T0_heal_ballade.yml
@@ -34,6 +34,7 @@
 - type: entity
   id: CP14AreaEntityEffectHealBallade
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: TimedDespawn
     lifetime: 1.6
@@ -66,6 +67,7 @@
   id: CP14ImpactEffectHealthBallade
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     sprite: _CP14/Effects/music.rsi
@@ -78,6 +80,7 @@
   id: CP14RuneHealBallade
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#79b330"

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/T0_peace_ballade.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/T0_peace_ballade.yml
@@ -34,6 +34,7 @@
 - type: entity
   id: CP14AreaEntityEffectPeaceBallade
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: TimedDespawn
     lifetime: 1.6
@@ -59,6 +60,7 @@
   id: CP14ImpactEffectPeaceBallade
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     sprite: _CP14/Effects/music.rsi
@@ -71,6 +73,7 @@
   id: CP14RunePeaceBallade
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#bd4fda"

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/T0_plant_growth.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/T0_plant_growth.yml
@@ -95,6 +95,7 @@
   id: CP14ImpactEffectPlantGrowth
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     layers:
@@ -106,6 +107,7 @@
   id: CP14RunePlantGrowth
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#328643"

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/T0_speed_ballade.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/T0_speed_ballade.yml
@@ -34,6 +34,7 @@
 - type: entity
   id: CP14AreaEntityEffectSpeedBallade
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: TimedDespawn
     lifetime: 1.6
@@ -58,6 +59,7 @@
   id: CP14ImpactEffectSpeedBallade
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     sprite: _CP14/Effects/music.rsi
@@ -70,6 +72,7 @@
   id: CP14RuneSpeedBallade
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#e8cb56"

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/magical_acceleration.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/magical_acceleration.yml
@@ -32,6 +32,7 @@
   id: CP14MagicAccelerationDustEffect
   parent: CP14DustEffect
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     drawdepth: Items

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Light/T0_sphere_of_light.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Light/T0_sphere_of_light.yml
@@ -38,6 +38,7 @@
   id: CP14RuneSphereOfLight
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#efedff"
@@ -51,6 +52,7 @@
   id: CP14ImpactEffectSphereOfLight
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Light/T1_flash_light.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Light/T1_flash_light.yml
@@ -39,6 +39,7 @@
   id: CP14RuneFlashLight
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#efedff"
@@ -52,6 +53,7 @@
   id: CP14ImpactEffectFlashLight
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     layers:
@@ -62,6 +64,7 @@
 - type: entity
   id: CP14SpawnEffectFlashLight
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     sprite: /Textures/Objects/Fun/goldbikehorn.rsi
@@ -79,6 +82,7 @@
 - type: entity
   id: CP14SpellFlashEffect
   categories: [ HideSpawnMenu ]
+  save: false
   components:
     - type: PointLight
       enabled: true

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Light/T1_signal_light.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Light/T1_signal_light.yml
@@ -43,6 +43,7 @@
   id: CP14RuneSignalLightRed
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#db1616"
@@ -87,6 +88,7 @@
   id: CP14RuneSignalLightYellow
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#ebc942"
@@ -131,6 +133,7 @@
   id: CP14RuneSignalLightBlue
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#42aaeb"

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Meta/T0_mana_ballade.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Meta/T0_mana_ballade.yml
@@ -35,6 +35,7 @@
 - type: entity
   id: CP14AreaEntityEffectMagicBallade
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: TimedDespawn
     lifetime: 1.6
@@ -59,6 +60,7 @@
   id: CP14ImpactEffectMagicBallade
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     sprite: _CP14/Effects/music.rsi
@@ -71,6 +73,7 @@
   id: CP14RuneMagicBallade
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#5096d4"

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Meta/T0_mana_consume.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Meta/T0_mana_consume.yml
@@ -55,6 +55,7 @@
   id: CP14RuneManaConsume
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#5096d4"
@@ -71,6 +72,7 @@
   id: CP14ImpactEffectManaConsume
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Meta/T0_mana_gift.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Meta/T0_mana_gift.yml
@@ -58,6 +58,7 @@
   id: CP14RuneManaGift
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#5096d4"
@@ -74,6 +75,7 @@
   id: CP14ImpactEffectManaGift
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Meta/T0_mana_splitting.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Meta/T0_mana_splitting.yml
@@ -49,6 +49,7 @@
   id: CP14RuneMagicSplitting
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#5096d4"
@@ -62,6 +63,7 @@
   id: CP14ImpactEffectMagicSplitting
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     sprite: Effects/electricity.rsi

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Physical/T0_Kick.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Physical/T0_Kick.yml
@@ -50,6 +50,7 @@
   id: CP14DustEffectKickSound
   parent: CP14DustEffect
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: EmitSoundOnSpawn
     sound: !type:SoundPathSpecifier

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Vampire/T0_Bite.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Vampire/T0_Bite.yml
@@ -46,8 +46,9 @@
   
 - type: entity
   id: CP14ImpactEffectVampireBite
-  parent: CP14SnowEffect 
+  parent: CP14SnowEffect
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Vampire/T1_Hypnosis.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Vampire/T1_Hypnosis.yml
@@ -62,6 +62,7 @@
   id: CP14ImpactEffectVampireHypnosis
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     sprite: Effects/electricity.rsi

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Vampire/T2_Blood_step.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Vampire/T2_Blood_step.yml
@@ -36,6 +36,7 @@
   id: CP14ImpactEffectBloodStep
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/beer_creation.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/beer_creation.yml
@@ -7,7 +7,7 @@
     sprite: _CP14/Actions/Spells/water.rsi
     state: beer_creation
   - type: CP14MagicEffectManaCost
-    manaCost: 50
+    manaCost: 20
   - type: CP14MagicEffect
     effects:
     - !type:CP14SpellSpawnEntityOnTarget
@@ -30,7 +30,7 @@
       sprite: _CP14/Actions/Spells/water.rsi
       state: beer_creation
     event: !type:CP14DelayedInstantActionEvent
-      cooldown: 60
+      cooldown: 30
       castDelay: 5
       breakOnMove: true
 
@@ -38,6 +38,7 @@
   id: CP14RuneBeerCreation
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#5eabeb"
@@ -68,6 +69,7 @@
   id: CP14ImpactEffectBeerCreation
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/freeze.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/freeze.yml
@@ -47,6 +47,7 @@
   id: CP14ImpactEffectFreeze
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     layers:
@@ -58,6 +59,7 @@
   id: CP14RunePlantFreeze
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#5eabeb"

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/ice_shards.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/ice_shards.yml
@@ -40,6 +40,7 @@
   id: CP14RuneIceShards
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#5eabeb"
@@ -54,6 +55,7 @@
   parent: BaseBullet
   name: ice shard
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#5eabeb"

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/water_creation.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/water_creation.yml
@@ -35,6 +35,7 @@
   id: CP14RuneWaterCreation
   parent: CP14BaseMagicRune
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: PointLight
     color: "#5eabeb"
@@ -144,6 +145,7 @@
   id: CP14ImpactEffectWaterCreation
   parent: CP14BaseMagicImpact
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_CP14/Entities/Effects/alchemy_effects.yml
+++ b/Resources/Prototypes/_CP14/Entities/Effects/alchemy_effects.yml
@@ -3,6 +3,7 @@
   id: CP14Mist
   name: mist
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     sprite: _CP14/Effects/mist.rsi

--- a/Resources/Prototypes/_CP14/Entities/Effects/visual_effect.yml
+++ b/Resources/Prototypes/_CP14/Entities/Effects/visual_effect.yml
@@ -1,6 +1,7 @@
 - type: entity
   id: CP14DirtEffect
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     sprite: _CP14/Effects/material_splash.rsi
@@ -26,6 +27,7 @@
   id: CP14SnowEffect
   parent: CP14DirtEffect
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     layers:
@@ -40,6 +42,7 @@
 - type: entity
   id: CP14DustEffect
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: TimedDespawn
     lifetime: 0.4
@@ -56,6 +59,7 @@
 - type: entity
   id: CP14MagicBeam1
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     sprite: /Textures/_CP14/Effects/Beams/magic.rsi
@@ -75,6 +79,7 @@
 - type: entity
   id: CP14ElectrifiedEffect
   categories: [ HideSpawnMenu ]
+  save: false
   components:
   - type: Sprite
     sprite: Effects/electricity.rsi

--- a/Resources/Prototypes/_CP14/Entities/Effects/weapon_arc.yml
+++ b/Resources/Prototypes/_CP14/Entities/Effects/weapon_arc.yml
@@ -2,6 +2,7 @@
   id: CP14WeaponArcSlash
   parent: WeaponArcStatic
   categories: [ HideSpawnMenu ]
+  save: false
   components:
     - type: WeaponArcVisuals
       animation: CPSlash
@@ -10,6 +11,7 @@
   id: CP14WeaponArcThrust
   parent: WeaponArcStatic
   categories: [ HideSpawnMenu ]
+  save: false
   components:
     - type: WeaponArcVisuals
       animation: CPThrust

--- a/Resources/Prototypes/_CP14/Entities/Mobs/Species/carcat.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/Species/carcat.yml
@@ -41,6 +41,9 @@
   - type: CP14NightVision #Night vision
   - type: FootstepModifier
     footstepSoundCollection: null # Silent footstep
+  - type: CP14SkillStorage
+    progress:
+      Atlethic: 1
   - type: Inventory
     templateId: CP14Carcat # Cant wear shoes
     speciesId: carcat

--- a/Resources/Prototypes/_CP14/Entities/Mobs/Species/elf.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/Species/elf.yml
@@ -25,6 +25,9 @@
     requiredLegs: 2
   - type: Bloodstream
     bloodReagent: CP14BloodElf
+  - type: CP14SkillStorage
+    progress:
+      Metamagic: 1
   - type: CP14MagicEnergyContainer #Increased mana container
     maxEnergy: 200
     energy: 200

--- a/Resources/Prototypes/_CP14/Entities/Mobs/Species/silva.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/Species/silva.yml
@@ -76,6 +76,9 @@
   #- type: CP14MagicEnergyPhotosynthesis # Silva special feature #Disabled until sunlight fixed
   #- type: CP14MagicEnergyDraw #Enabled default mana regen until sunlight fixed
   #  enable: false
+  - type: CP14SkillStorage
+    progress:
+      Healing: 1
   - type: Body
     prototype: CP14Silva
     requiredLegs: 2

--- a/Resources/Prototypes/_CP14/Entities/Mobs/Species/tiefling.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/Species/tiefling.yml
@@ -47,10 +47,13 @@
     globalModifier: 1.2
     modifiers:
       Fire: 0.5
+  - type: CP14SkillStorage
+    progress:
+      Pyrokinetic: 1
   - type: CP14SpellStorage
-    grantAccessToSelf: true
-    spells:
-    - CP14ActionSpellTieflingInnerFire
+    #grantAccessToSelf: true
+    #spells:
+    #- CP14ActionSpellTieflingInnerFire
   - type: Inventory
     templateId: CP14Human
     femaleDisplacements:

--- a/Resources/Prototypes/_CP14/Loadouts/skill_tree.yml
+++ b/Resources/Prototypes/_CP14/Loadouts/skill_tree.yml
@@ -26,14 +26,7 @@
   id: CP14SkillTreePyrokinetic
   dummyEntity: CP14SkillTreePyrokineticLoadoutDummy
   skillTree:
-    Pyrokinetic: 2
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:TraitsRequirement
-      inverted: true
-      traits:
-      - CP14ManaWasting
+    Pyrokinetic: 1
 
 
 
@@ -50,14 +43,7 @@
   id: CP14SkillTreeHydrosophistry
   dummyEntity: CP14SkillTreeHydrosophistryLoadoutDummy
   skillTree:
-    Hydrosophistry: 2
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:TraitsRequirement
-      inverted: true
-      traits:
-      - CP14ManaWasting
+    Hydrosophistry: 1
 
 
 - type: entity
@@ -73,14 +59,7 @@
   id: CP14SkillTreeIllusion
   dummyEntity: CP14SkillTreeIllusionLoadoutDummy
   skillTree:
-    Illusion: 2
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:TraitsRequirement
-      inverted: true
-      traits:
-      - CP14ManaWasting
+    Illusion: 1
 
 
 - type: entity
@@ -96,14 +75,7 @@
   id: CP14SkillTreeMetamagic
   dummyEntity: CP14SkillTreeMetamagicLoadoutDummy
   skillTree:
-    Metamagic: 2
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:TraitsRequirement
-      inverted: true
-      traits:
-      - CP14ManaWasting
+    Metamagic: 1
 
 
 - type: entity
@@ -119,14 +91,7 @@
   id: CP14SkillTreeHealing
   dummyEntity: CP14SkillTreeHealingLoadoutDummy
   skillTree:
-    Healing: 2
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:TraitsRequirement
-      inverted: true
-      traits:
-      - CP14ManaWasting
+    Healing: 1
 
 
 - type: entity
@@ -142,4 +107,4 @@
   id: CP14SkillTreeAtlethic
   dummyEntity: CP14SkillTreeAtlethicLoadoutDummy
   skillTree:
-    Atlethic: 2
+    Atlethic: 1

--- a/Resources/Prototypes/_CP14/Skill/healing.yml
+++ b/Resources/Prototypes/_CP14/Skill/healing.yml
@@ -2,7 +2,7 @@
   id: CP14ActionSpellCureBurn
   skillUiPosition: 0, 0
   tree: Healing
-  learnCost: 10 #Temp disable healing
+  learnCost: 1
   icon:
     sprite: _CP14/Actions/Spells/healing.rsi
     state: cure_burn
@@ -12,7 +12,7 @@
 - type: cp14Skill
   id: CP14ActionSpellBloodPurification
   skillUiPosition: 2, 0
-  learnCost: 10 #Temp disable healing
+  learnCost: 1
   tree: Healing
   icon:
     sprite: _CP14/Actions/Spells/healing.rsi
@@ -23,7 +23,7 @@
 - type: cp14Skill
   id: CP14ActionSpellCureWounds
   skillUiPosition: 4, 0
-  learnCost: 10 #Temp disable healing
+  learnCost: 1
   tree: Healing
   icon:
     sprite: _CP14/Actions/Spells/healing.rsi
@@ -44,7 +44,7 @@
 - type: cp14Skill
   id: CP14ActionSpellHealBallade
   skillUiPosition: 0, 6
-  learnCost: 10 #Temp disable healing
+  learnCost: 1
   tree: Healing
   icon:
     sprite: _CP14/Actions/Spells/healing.rsi


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
<!-- Что вы изменили в своем пулл реквесте? -->
all spell effects marked as `save: false`, so its not saveable now
some species now have additional starting magic points
loadouts skill points reduced from 2 to 1