### PR TITLE
Aer and energia recolor

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Objects/Specific/Thaumaturgy/essence.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Specific/Thaumaturgy/essence.yml
@@ -95,7 +95,7 @@
   name: aer
   components:
   - type: Sprite
-    color: "#def9ff"
+    color: "#fdfe86"
   - type: SolutionContainerManager
     solutions:
       essence:

--- a/Resources/Prototypes/_CP14/Entities/Structures/Flora/Crystal/elemental.yml
+++ b/Resources/Prototypes/_CP14/Entities/Structures/Flora/Crystal/elemental.yml
@@ -183,9 +183,9 @@
   suffix: Aer
   components:
   - type: PointLight
-    color: "#def9ff"
+    color: "#fdfe86"
   - type: Sprite
-    color: "#def9ff"
+    color: "#fdfe86"
   - type: Destructible
     thresholds:
       - trigger:

--- a/Resources/Prototypes/_CP14/Entities/Structures/Flora/Crystal/shards.yml
+++ b/Resources/Prototypes/_CP14/Entities/Structures/Flora/Crystal/shards.yml
@@ -70,7 +70,7 @@
   name: aer quartz shard
   components:
   - type: Sprite
-    color: "#def9ff"
+    color: "#fdfe86"
   - type: CP14MagicEssenceContainer
     essences:
       Air: 3

--- a/Resources/Prototypes/_CP14/Entities/Structures/Specific/Thaumaturgy/essence_nodes.yml
+++ b/Resources/Prototypes/_CP14/Entities/Structures/Specific/Thaumaturgy/essence_nodes.yml
@@ -93,9 +93,9 @@
   suffix: aer
   components:
   - type: PointLight
-    color: "#def9ff"
+    color: "#fdfe86"
   - type: Sprite
-    color: "#def9ff"
+    color: "#fdfe86"
   - type: TimedSpawner
     prototypes:
     - CP14EssenceAir

--- a/Resources/Prototypes/_CP14/Reagents/magic_essence.yml
+++ b/Resources/Prototypes/_CP14/Reagents/magic_essence.yml
@@ -51,7 +51,7 @@
   name: cp14-reagent-name-essence-air
   desc: cp14-reagent-desc-essence-air
   group: CP14MagicEssenceT0
-  color: "#def9ff"
+  color: "#fdfe86"
   tileReactions:
   - !type:CreateEntityTileReaction
     entity: CP14EssenceAir
@@ -130,7 +130,7 @@
   name: cp14-reagent-name-essence-energia
   desc: cp14-reagent-desc-essence-energia
   group: CP14MagicEssenceT1
-  color: "#caed72"
+  color: "#c0ffff"
   tileReactions:
   - !type:CreateEntityTileReaction
     entity: CP14EssenceEnergia


### PR DESCRIPTION
## About the PR
Aer and energia was recolored

## Why / Balance
Because aer and ordo was almost same color; energia was recolored cuz yellow is not cool

## Media
![image](https://github.com/user-attachments/assets/24a4b527-47b5-4cf1-b985-f2abddf08f51)
aer energia ordo