### PR TITLE
[Fix]Mana heal/damage potion fix

### DIFF
--- a/Content.Server/_CP14/Chemistry/ReagentEffect/CP14ManaChange.cs
+++ b/Content.Server/_CP14/Chemistry/ReagentEffect/CP14ManaChange.cs
@@ -17,6 +17,9 @@ public sealed partial class CP14ManaChange : EntityEffect
     [DataField]
     public bool Safe = false;
 
+    [DataField]
+    public bool ScaleByQuantity;
+
     protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
     {
         return Loc.GetString(ManaDelta >= 0 ? "cp14-reagent-effect-guidebook-mana-add" : "cp14-reagent-effect-guidebook-mana-remove",
@@ -30,7 +33,7 @@ public sealed partial class CP14ManaChange : EntityEffect
 
         if (args is EntityEffectReagentArgs reagentArgs)
         {
-            scale = reagentArgs.Quantity * reagentArgs.Scale;
+            scale = ScaleByQuantity ? reagentArgs.Quantity * reagentArgs.Scale : reagentArgs.Scale;
         }
 
         var magicSystem = args.EntityManager.System<CP14MagicEnergySystem>();

--- a/Resources/Prototypes/_CP14/Reagents/target_effects.yml
+++ b/Resources/Prototypes/_CP14/Reagents/target_effects.yml
@@ -8,7 +8,7 @@
   physicalDesc: cp14-reagent-physical-desc-colorless
 
 # T1 / Simple or Basic solutions
-# Have simple effects, shouldn't be able to replace their occupational 
+# Have simple effects, shouldn't be able to replace their occupational
 
 - type: reagent
   id: CP14BasicEffectHealBrute
@@ -275,7 +275,7 @@
       metabolismRate: 0.05
       effects:
       - !type:CP14ManaChange
-        manaDelta: 30
+        manaDelta: 1.5
         safe: true
 
 - type: reagent
@@ -291,7 +291,7 @@
       metabolismRate: 0.05
       effects:
       - !type:CP14ManaChange
-        manaDelta: -30
+        manaDelta: -1.5
         safe: false
 
 - type: reagent
@@ -333,7 +333,7 @@
       - !type:GenericStatusEffect
         key: Stutter
         component: StutteringAccent
-        
+
 - type: reagent
   id: CP14BasicEffectSleep
   name: cp14-reagent-name-basic-sleep
@@ -354,7 +354,7 @@
         key: ForcedSleep
         component: ForcedSleeping
         type: Add
-        
+
 - type: reagent
   id: CP14BasicEffectUnsleep
   name: cp14-reagent-name-basic-unsleep
@@ -389,7 +389,7 @@
         amount: -10
 
 # Gimmick solutions, otherwise doesn't give a mechanical benefit
-  
+
 - type: reagent
   id: CP14BasicEffectRainbow
   name: cp14-reagent-name-see-rainbow


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
<!-- Что вы изменили в своем пулл реквесте? -->
Теперь, востановление маны работает как у других веществ, и при метаболизме 0.05 лечит 1.5 в итоге выйдет 30 маны.

Now, mana potion works like other , and with metabolism 0.05 heals 1.5, you'll end up with 30 mana.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
<!-- Зачем нужно это изменение? Прикрепите любые обсуждения или проблемы здесь. Опишите, как это повлияет на текущий баланс игры. -->
Fix #1032 
## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->
<!--
Пулл реквесты, которые несут за собой игровые изменения (добавления одежды, предметов и так далее) требуют чтобы вы прикрепили скриншоты или видеоролики, демонстрирующие эти изменения.
Небольшие исправления не считаются.
-->
![image](https://github.com/user-attachments/assets/8271092b-19f0-48f7-8cc6-a14ab938387f)
