### PR TITLE
[Fix]CP14FloorWaterOptimized fix

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Structures/Floor/floorWater.yml
+++ b/Resources/Prototypes/_CP14/Entities/Structures/Floor/floorWater.yml
@@ -3,6 +3,7 @@
   id: CP14FloorWaterOptimized
   name: water
   description: A trough of plain water. Clean enough for consumption
+  suffix: Optimized, Ocean
   categories: [ ForkFiltered ]
   placement:
     mode: SnapgridCenter
@@ -65,13 +66,14 @@
 - type: entity
   parent: CP14FloorWaterOptimized
   id: CP14FloorWater
+  suffix: Full
   components:
   - type: DrawableSolution
     solution: pool
   - type: SolutionContainerManager
     solutions:
       pool:
-        maxVol: 9999999 #.inf seems to break the whole yaml file, but would definitely be preferable. 
+        maxVol: 9999999 #.inf seems to break the whole yaml file, but would definitely be preferable.
         reagents:
         - ReagentId: Water
           Quantity: 9999999

--- a/Resources/Prototypes/_CP14/Entities/Structures/Floor/floorWater.yml
+++ b/Resources/Prototypes/_CP14/Entities/Structures/Floor/floorWater.yml
@@ -3,8 +3,7 @@
   id: CP14FloorWaterOptimized
   name: water
   description: A trough of plain water. Clean enough for consumption
-  suffix: Optimized, Ocean
-  categories: [ ForkFiltered ]
+  categories: [ HideSpawnMenu ]
   placement:
     mode: SnapgridCenter
     snap:
@@ -66,7 +65,7 @@
 - type: entity
   parent: CP14FloorWaterOptimized
   id: CP14FloorWater
-  suffix: Full
+  categories: [ ForkFiltered ]
   components:
   - type: DrawableSolution
     solution: pool


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
<!-- Что вы изменили в своем пулл реквесте? -->
```CP14FloorWaterOptimized``` больше нельзя заспавнить через панель.
``CP14FloorWaterOptimized`` can no longer be spawned from panel.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
<!-- Зачем нужно это изменение? Прикрепите любые обсуждения или проблемы здесь. Опишите, как это повлияет на текущий баланс игры. -->
Fix #1093 
## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->
<!--
Пулл реквесты, которые несут за собой игровые изменения (добавления одежды, предметов и так далее) требуют чтобы вы прикрепили скриншоты или видеоролики, демонстрирующие эти изменения.
Небольшие исправления не считаются.
-->

