### PR TITLE
Magic modifier armour

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Clothing/OuterClothing/ModularArmor/Breastplate/chainmail.yml
+++ b/Resources/Prototypes/_CP14/Entities/Clothing/OuterClothing/ModularArmor/Breastplate/chainmail.yml
@@ -19,6 +19,8 @@
     sprintModifier: 0.99
   - type: CP14ModularCraftStartPoint
     startProtoPart: CP14ArmorIronChainmail
+  - type: CP14MagicManacostModify
+    globalModifier: 1.15
   - type: CP14Material
     materials:
       CP14Iron: 40
@@ -60,6 +62,8 @@
     sprintModifier: 0.98
   - type: CP14ModularCraftStartPoint
     startProtoPart: CP14ArmorGoldChainmail
+  - type: CP14MagicManacostModify
+    globalModifier: 1.05
   - type: CP14Material
     materials:
       CP14Gold: 40
@@ -98,6 +102,8 @@
         Piercing: 0.99
   - type: CP14ModularCraftStartPoint
     startProtoPart: CP14ArmorCopperChainmail
+  - type: CP14MagicManacostModify
+    globalModifier: 1.1
   - type: CP14Material
     materials:
       CP14Copper: 40
@@ -139,6 +145,8 @@
     sprintModifier: 0.99
   - type: CP14ModularCraftStartPoint
     startProtoPart: CP14ArmorMithrilChainmail
+  - type: CP14MagicManacostModify
+    globalModifier: 0.96
   - type: CP14Material
     materials:
       CP14Mithril: 40

--- a/Resources/Prototypes/_CP14/Entities/Clothing/OuterClothing/ModularArmor/Breastplate/cuirass.yml
+++ b/Resources/Prototypes/_CP14/Entities/Clothing/OuterClothing/ModularArmor/Breastplate/cuirass.yml
@@ -35,6 +35,8 @@
     sprintModifier: 0.95
   - type: CP14ModularCraftStartPoint
     startProtoPart: CP14ArmorIronCuirass
+  - type: CP14MagicManacostModify
+    globalModifier: 1.2
   - type: CP14Material
     materials:
       CP14Iron: 50
@@ -77,6 +79,8 @@
     sprintModifier: 0.90
   - type: CP14ModularCraftStartPoint
     startProtoPart: CP14ArmorGoldCuirass
+  - type: CP14MagicManacostModify
+    globalModifier: 1.1
   - type: CP14Material
     materials:
       CP14Gold: 50
@@ -119,6 +123,8 @@
     sprintModifier: 0.98
   - type: CP14ModularCraftStartPoint
     startProtoPart: CP14ArmorCopperCuirass
+  - type: CP14MagicManacostModify
+    globalModifier: 1.15
   - type: CP14Material
     materials:
       CP14Copper: 50
@@ -161,6 +167,8 @@
     sprintModifier: 0.98
   - type: CP14ModularCraftStartPoint
     startProtoPart: CP14ArmorMithrilCuirass
+  - type: CP14MagicManacostModify
+    globalModifier: 0.95
   - type: CP14Material
     materials:
       CP14Mithril: 50

--- a/Resources/Prototypes/_CP14/Entities/Clothing/OuterClothing/ModularArmor/Breastplate/infantry_cuirass.yml
+++ b/Resources/Prototypes/_CP14/Entities/Clothing/OuterClothing/ModularArmor/Breastplate/infantry_cuirass.yml
@@ -20,6 +20,8 @@
     sprintModifier: 0.93
   - type: CP14ModularCraftStartPoint
     startProtoPart: CP14ArmorIronInfantryCuirass
+  - type: CP14MagicManacostModify
+    globalModifier: 1.24
   - type: CP14Material
     materials:
       CP14Iron: 60
@@ -62,6 +64,8 @@
     sprintModifier: 0.88
   - type: CP14ModularCraftStartPoint
     startProtoPart: CP14ArmorGoldInfantryCuirass
+  - type: CP14MagicManacostModify
+    globalModifier: 1.14
   - type: CP14Material
     materials:
       CP14Gold: 60
@@ -104,6 +108,8 @@
     sprintModifier: 0.96
   - type: CP14ModularCraftStartPoint
     startProtoPart: CP14ArmorCopperInfantryCuirass
+  - type: CP14MagicManacostModify
+    globalModifier: 1.18
   - type: CP14Material
     materials:
       CP14Copper: 60
@@ -146,6 +152,8 @@
     sprintModifier: 0.96
   - type: CP14ModularCraftStartPoint
     startProtoPart: CP14ArmorMithrilInfantryCuirass
+  - type: CP14MagicManacostModify
+    globalModifier: 0.92
   - type: CP14Material
     materials:
       CP14Mithril: 60

--- a/Resources/Prototypes/_CP14/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_CP14/Entities/Clothing/OuterClothing/armor.yml
@@ -19,6 +19,8 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.96
     sprintModifier: 0.96
+  - type: CP14MagicManacostModify
+    globalModifier: 1.1
 
 - type: entity
   parent: CP14ClothingOuterClothingBase


### PR DESCRIPTION
## About the PR

Armour now gives a modifier to the cost of using spells. Iron armour gives the most cost, gold armour on the contrary gives less cost. Mithril armour, on the contrary, makes spells cheaper.
Броня теперь дает модификатор к стоимости использования заклинаний. Железные доспехи дают больше затрат, золотые, наоборот, меньше. Мифриловая броня, наоборот, удешевляет заклинания.

## Why / Balance

Those who develop magic more will now have to do more thinking and balancing of their equipment, rather than just taking all the coolest stuff and essentially being no different from a warrior. 
Тем, кто больше развивает магию, теперь придется больше думать и балансировать свое снаряжение, а не просто брать все самое крутое и по сути ничем не отличаться от воина. 

## Media

![изображение](https://github.com/user-attachments/assets/0f18f848-8cd3-4c50-8565-e21949218e1b)
