### PR TITLE
Базовое зелье маны лечит мёртвых

### DIFF
--- a/Resources/Prototypes/_CP14/Reagents/target_effects.yml
+++ b/Resources/Prototypes/_CP14/Reagents/target_effects.yml
@@ -305,6 +305,7 @@
   group: CP14BasicEffect
   flavor: CP14Magic
   color: "#1497e3"
+  worksOnTheDead: true
   physicalDesc: cp14-reagent-physical-desc-iridescent
   metabolisms:
     Medicine:
@@ -321,6 +322,7 @@
   group: CP14BasicEffect
   flavor: CP14Bitterly
   color: "#6014e3"
+  worksOnTheDead: true
   physicalDesc: cp14-reagent-physical-desc-iridescent
   metabolisms:
     Poison:


### PR DESCRIPTION
## About the PR
Урон добавили, даже раствор новый, но зелье базовой маны мёртвых не лечит (а ещё это вебэдит)

## Why / Balance
Чтоб алхимику жилось хорошо
