### PR TITLE
New Status Effect system

### DIFF
--- a/Content.Shared/_CP14/MagicSpell/Spells/CP14SpellApplyStatusEffect.cs
+++ b/Content.Shared/_CP14/MagicSpell/Spells/CP14SpellApplyStatusEffect.cs
@@ -1,0 +1,25 @@
+using Content.Shared._CP14.StatusEffect;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._CP14.MagicSpell.Spells;
+
+public sealed partial class CP14SpellApplyStatusEffect : CP14SpellEffect
+{
+    [DataField(required: true)]
+    public EntProtoId StatusEffect = new();
+
+    [DataField]
+    public TimeSpan? Duration = null;
+
+    public override void Effect(EntityManager entManager, CP14SpellEffectBaseArgs args)
+    {
+        if (args.Target is null)
+            return;
+
+        var targetEntity = args.Target.Value;
+
+        var statusEffectSys = entManager.System<CP14SharedStatusEffectSystem>();
+
+        statusEffectSys.TryAddStatusEffect(targetEntity, StatusEffect, Duration);
+    }
+}

--- a/Content.Shared/_CP14/MagicSpell/Spells/CP14SpellApplyStatusEffect.cs
+++ b/Content.Shared/_CP14/MagicSpell/Spells/CP14SpellApplyStatusEffect.cs
@@ -6,10 +6,13 @@ namespace Content.Shared._CP14.MagicSpell.Spells;
 public sealed partial class CP14SpellApplyStatusEffect : CP14SpellEffect
 {
     [DataField(required: true)]
-    public EntProtoId StatusEffect = new();
+    public EntProtoId StatusEffect;
 
     [DataField]
-    public TimeSpan? Duration = null;
+    public TimeSpan? Duration;
+
+    [DataField]
+    public bool ResetCooldown = true;
 
     public override void Effect(EntityManager entManager, CP14SpellEffectBaseArgs args)
     {
@@ -20,6 +23,6 @@ public sealed partial class CP14SpellApplyStatusEffect : CP14SpellEffect
 
         var statusEffectSys = entManager.System<CP14SharedStatusEffectSystem>();
 
-        statusEffectSys.TryAddStatusEffect(targetEntity, StatusEffect, Duration);
+        statusEffectSys.TryAddStatusEffect(targetEntity, StatusEffect, Duration, ResetCooldown);
     }
 }

--- a/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.API.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.API.cs
@@ -4,6 +4,16 @@ namespace Content.Shared._CP14.StatusEffect;
 
 public sealed partial class CP14SharedStatusEffectSystem
 {
+    /// <summary>
+    /// Attempts to add a status effect to the specified entity. Returns True if the effect is added or exists
+    /// and has been successfully extended in time, returns False if the status effect cannot be applied to this entity,
+    /// or for any other reason
+    /// </summary>
+    /// <param name="uid">The target entity on which the effect is added</param>
+    /// <param name="effectProto">ProtoId of the status effect entity. Make sure it has CP14StatusEffectComponent on it</param>
+    /// <param name="duration">Duration of status effect. Leave null and the effect will be permanent until it is removed using <c>TryRemoveStatusEffect</c>
+    /// In the other case, the effect will either be added for the specified time or its time will be extended for the specified time.</param>
+    /// <returns></returns>
     public bool TryAddStatusEffect(EntityUid uid, EntProtoId effectProto, TimeSpan? duration = null)
     {
         if (TryGetStatusEffect(uid, effectProto, out var existedEffect))
@@ -53,6 +63,9 @@ public sealed partial class CP14SharedStatusEffectSystem
         return true;
     }
 
+    /// <summary>
+    /// Attempting to remove a status effect from an entity. Returns True if the status effect existed on the entity and was successfully removed, and False in any other case.
+    /// </summary>
     public bool TryRemoveStatusEffect(EntityUid uid, EntProtoId effectProto)
     {
         if (!_containerQuery.TryComp(uid, out var container))
@@ -73,6 +86,9 @@ public sealed partial class CP14SharedStatusEffectSystem
         return true;
     }
 
+    /// <summary>
+    /// Checks whether the specified entity is under a specific status effect.
+    /// </summary>
     public bool HasStatusEffect(EntityUid uid, EntProtoId effectProto)
     {
         if (!_containerQuery.TryComp(uid, out var container))
@@ -81,6 +97,9 @@ public sealed partial class CP14SharedStatusEffectSystem
         return container.ActiveStatusEffects.ContainsKey(effectProto);
     }
 
+    /// <summary>
+    /// Attempting to retrieve the EntityUid of a status effect from an entity.
+    /// </summary>
     public bool TryGetStatusEffect(EntityUid uid, EntProtoId effectProto, out EntityUid? effect)
     {
         if (!_containerQuery.TryComp(uid, out var container))

--- a/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.API.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.API.cs
@@ -46,7 +46,7 @@ public sealed partial class CP14SharedStatusEffectSystem
         container.ActiveStatusEffects.Add(effectProto, effect);
         effectComp.AppliedTo = uid;
 
-        var ev = new CP14StatusEffectApplied(uid, effect);
+        var ev = new CP14StatusEffectApplied(uid, (effect, effectComp));
         RaiseLocalEvent(uid, ev);
         RaiseLocalEvent(effect, ev);
 
@@ -58,14 +58,17 @@ public sealed partial class CP14SharedStatusEffectSystem
         if (!_containerQuery.TryComp(uid, out var container))
             return false;
 
-        if (!container.ActiveStatusEffects.TryGetValue(effectProto, out var statusEffect))
+        if (!container.ActiveStatusEffects.TryGetValue(effectProto, out var effect))
             return false;
 
-        var ev = new CP14StatusEffectRemoved(uid, statusEffect);
-        RaiseLocalEvent(uid, ev);
-        RaiseLocalEvent(statusEffect, ev);
+        if (!_effectQuery.TryComp(effect, out var effectComp))
+            return false;
 
-        QueueDel(statusEffect);
+        var ev = new CP14StatusEffectRemoved(uid, (effect, effectComp));
+        RaiseLocalEvent(uid, ev);
+        RaiseLocalEvent(effect, ev);
+
+        QueueDel(effect);
         container.ActiveStatusEffects.Remove(effectProto);
         return true;
     }

--- a/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.API.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.API.cs
@@ -48,6 +48,23 @@ public sealed partial class CP14SharedStatusEffectSystem
         return true;
     }
 
+    public bool TryRemoveStatusEffect(EntityUid uid, EntProtoId effectProto)
+    {
+        if (!_containerQuery.TryComp(uid, out var container))
+            return false;
+
+        if (!container.ActiveStatusEffects.TryGetValue(effectProto, out var statusEffect))
+            return false;
+
+        var ev = new CP14StatusEffectRemoved(uid, statusEffect);
+        RaiseLocalEvent(uid, ev);
+        RaiseLocalEvent(statusEffect, ev);
+
+        QueueDel(statusEffect);
+        container.ActiveStatusEffects.Remove(effectProto);
+        return true;
+    }
+
     public bool HasStatusEffect(EntityUid uid, EntProtoId effectProto)
     {
         if (!_containerQuery.TryComp(uid, out var container))

--- a/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.API.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.API.cs
@@ -53,7 +53,8 @@ public sealed partial class CP14SharedStatusEffectSystem
         EnsureComp<CP14StatusEffectContainerComponent>(uid, out var container);
 
         //And only if all checks passed we spawn the effect
-        var effect = Spawn(effectProto);
+        var effect = SpawnAttachedTo(effectProto, Transform(uid).Coordinates);
+        _transform.SetParent(effect, uid);
 
         if (!_effectQuery.TryComp(effect, out var effectComp))
             return false;

--- a/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.API.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.API.cs
@@ -43,7 +43,7 @@ public sealed partial class CP14SharedStatusEffectSystem
             return false;
         }
 
-        if (effectProtoComp.Whitelist is not null && !_whitelist.IsValid(effectProtoComp.Whitelist, uid))
+        if (!_whitelist.CheckBoth(uid, effectProtoComp.Blacklist, effectProtoComp.Whitelist))
             return false;
 
         //Technically, on the client, all checks have been successful and we do not need to execute further code related to entity spawning, as this is the server's responsibility

--- a/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.API.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.API.cs
@@ -1,0 +1,76 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._CP14.StatusEffect;
+
+public sealed partial class CP14SharedStatusEffectSystem
+{
+    public bool TryAddStatusEffect(EntityUid uid, EntProtoId effectProto, TimeSpan? duration = null)
+    {
+        EntityUid? effect = null;
+        if (TryGetStatusEffect(uid, effectProto, out effect))
+        {
+            //We dont need to add the effect if it already exists
+            if (duration is null)
+                return true;
+
+            if (effect != null)
+            {
+                AddStatusEffectTime(uid, effect.Value, duration.Value);
+                return true;
+            }
+        }
+
+        EnsureComp<CP14StatusEffectContainerComponent>(uid, out var container);
+
+        effect = Spawn(effectProto);
+
+        if (!_effectQuery.TryComp(effect, out var effectComp))
+        {
+            Log.Error(
+                $"Entity {effect} does not have a {nameof(CP14StatusEffectComponent)} component, but tried to apply it as a status effect on {ToPrettyString(uid):player}.");
+            QueueDel(effect);
+            return false;
+        }
+
+        // Duration configure
+        if (duration != null)
+        {
+            effectComp.EndEffectTime = _timing.CurTime + duration;
+        }
+
+        container.ActiveStatusEffects.Add(effectProto, effect.Value);
+        effectComp.AppliedTo = uid;
+
+        var ev = new CP14StatusEffectApplied(uid, effect.Value);
+        RaiseLocalEvent(uid, ev);
+        RaiseLocalEvent(effect.Value, ev);
+
+        return true;
+    }
+
+    public bool HasStatusEffect(EntityUid uid, EntProtoId effectProto)
+    {
+        if (!_containerQuery.TryComp(uid, out var container))
+            return false;
+
+        return container.ActiveStatusEffects.ContainsKey(effectProto);
+    }
+
+    public bool TryGetStatusEffect(EntityUid uid, EntProtoId effectProto, out EntityUid? effect)
+    {
+        if (!_containerQuery.TryComp(uid, out var container))
+        {
+            effect = null;
+            return false;
+        }
+
+        if (container.ActiveStatusEffects.TryGetValue(effectProto, out var statusEffect))
+        {
+            effect = statusEffect;
+            return true;
+        }
+
+        effect = null;
+        return false;
+    }
+}

--- a/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.API.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.API.cs
@@ -19,21 +19,26 @@ public sealed partial class CP14SharedStatusEffectSystem
             }
         }
 
+        // We make this checks before status effect entity spawned
         if (!_proto.TryIndex(effectProto, out var effectProtoData))
             return false;
 
-        if (!effectProtoData.TryGetComponent<CP14StatusEffectComponent>(out var effectComp, _compFactory))
+        if (!effectProtoData.TryGetComponent<CP14StatusEffectComponent>(out var effectProtoComp, _compFactory))
         {
             Log.Error($"Entity {effectProto} does not have a {nameof(CP14StatusEffectComponent)} component, but tried to apply it as a status effect on {ToPrettyString(uid)}.");
             return false;
         }
 
-        if (effectComp.Whitelist is not null && !_whitelist.IsValid(effectComp.Whitelist, uid))
+        if (effectProtoComp.Whitelist is not null && !_whitelist.IsValid(effectProtoComp.Whitelist, uid))
             return false;
 
         EnsureComp<CP14StatusEffectContainerComponent>(uid, out var container);
 
+        //And only if all checks passed we spawn the effect
         var effect = Spawn(effectProto);
+
+        if (!_effectQuery.TryComp(effect, out var effectComp))
+            return false;
 
         if (duration != null)
             effectComp.EndEffectTime = _timing.CurTime + duration;

--- a/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.API.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.API.cs
@@ -66,8 +66,8 @@ public sealed partial class CP14SharedStatusEffectSystem
         effectComp.AppliedTo = uid;
 
         var ev = new CP14StatusEffectApplied(uid, (effect, effectComp));
-        RaiseLocalEvent(uid, ev);
-        RaiseLocalEvent(effect, ev);
+        RaiseLocalEvent(uid, ref ev);
+        RaiseLocalEvent(effect, ref ev);
 
         return true;
     }
@@ -87,8 +87,8 @@ public sealed partial class CP14SharedStatusEffectSystem
             return false;
 
         var ev = new CP14StatusEffectRemoved(uid, (effect, effectComp));
-        RaiseLocalEvent(uid, ev);
-        RaiseLocalEvent(effect, ev);
+        RaiseLocalEvent(uid, ref ev);
+        RaiseLocalEvent(effect, ref ev);
 
         QueueDel(effect);
         container.ActiveStatusEffects.Remove(effectProto);

--- a/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.Effects.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.Effects.cs
@@ -10,17 +10,11 @@ public sealed partial class CP14SharedStatusEffectSystem
 
     private void AdditionalComponentsApply(Entity<CP14StatusEffectAdditionalComponentsComponent> ent, ref CP14StatusEffectApplied args)
     {
-        if (args.Effect.Comp.AppliedTo is null)
-            return;
-
-        EntityManager.AddComponents(args.Effect.Comp.AppliedTo.Value, ent.Comp.Components, ent.Comp.Overridde);
+        EntityManager.AddComponents(args.Target, ent.Comp.Components, ent.Comp.Overridde);
     }
 
     private void AdditionalComponentsRemove(Entity<CP14StatusEffectAdditionalComponentsComponent> ent, ref CP14StatusEffectRemoved args)
     {
-        if (args.Effect.Comp.AppliedTo is null)
-            return;
-
-        EntityManager.RemoveComponents(args.Effect.Comp.AppliedTo.Value, ent.Comp.Components);
+        EntityManager.RemoveComponents(args.Target, ent.Comp.Components);
     }
 }

--- a/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.Effects.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.Effects.cs
@@ -1,0 +1,26 @@
+namespace Content.Shared._CP14.StatusEffect;
+
+public sealed partial class CP14SharedStatusEffectSystem
+{
+    private void InitializeEffects()
+    {
+        SubscribeLocalEvent<CP14StatusEffectAdditionalComponentsComponent, CP14StatusEffectApplied>(AdditionalComponentsApply);
+        SubscribeLocalEvent<CP14StatusEffectAdditionalComponentsComponent, CP14StatusEffectRemoved>(AdditionalComponentsRemove);
+    }
+
+    private void AdditionalComponentsApply(Entity<CP14StatusEffectAdditionalComponentsComponent> ent, ref CP14StatusEffectApplied args)
+    {
+        if (args.Effect.Comp.AppliedTo is null)
+            return;
+
+        EntityManager.AddComponents(args.Effect.Comp.AppliedTo.Value, ent.Comp.Components, ent.Comp.Overridde);
+    }
+
+    private void AdditionalComponentsRemove(Entity<CP14StatusEffectAdditionalComponentsComponent> ent, ref CP14StatusEffectRemoved args)
+    {
+        if (args.Effect.Comp.AppliedTo is null)
+            return;
+
+        EntityManager.RemoveComponents(args.Effect.Comp.AppliedTo.Value, ent.Comp.Components);
+    }
+}

--- a/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.Effects.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.Effects.cs
@@ -60,7 +60,7 @@ public sealed partial class CP14SharedStatusEffectSystem
             if (statusEffect.AppliedTo is null)
                 continue;
 
-            spellEffect.NextUpdateTime = _timing.CurTime + spellEffect.UpdateFrequency;
+            spellEffect.NextUpdateTime += spellEffect.UpdateFrequency;
 
             foreach (var effect in spellEffect.UpdateEffect)
             {

--- a/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.Effects.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.Effects.cs
@@ -1,3 +1,5 @@
+using Content.Shared._CP14.MagicSpell.Spells;
+
 namespace Content.Shared._CP14.StatusEffect;
 
 public sealed partial class CP14SharedStatusEffectSystem
@@ -6,8 +8,17 @@ public sealed partial class CP14SharedStatusEffectSystem
     {
         SubscribeLocalEvent<CP14StatusEffectAdditionalComponentsComponent, CP14StatusEffectApplied>(AdditionalComponentsApply);
         SubscribeLocalEvent<CP14StatusEffectAdditionalComponentsComponent, CP14StatusEffectRemoved>(AdditionalComponentsRemove);
+
+        SubscribeLocalEvent<CP14StatusEffectApplySpellEffectComponent, CP14StatusEffectApplied>(SpellEffectApply);
+        SubscribeLocalEvent<CP14StatusEffectApplySpellEffectComponent, CP14StatusEffectRemoved>(SpellEffectRemove);
     }
 
+    private void UpdateEffects(float frameTime)
+    {
+        UpdateSpellEffect(frameTime);
+    }
+
+    #region CP14StatusEffectAdditionalComponentsComponent
     private void AdditionalComponentsApply(Entity<CP14StatusEffectAdditionalComponentsComponent> ent, ref CP14StatusEffectApplied args)
     {
         EntityManager.AddComponents(args.Target, ent.Comp.Components, ent.Comp.Overridde);
@@ -17,4 +28,45 @@ public sealed partial class CP14SharedStatusEffectSystem
     {
         EntityManager.RemoveComponents(args.Target, ent.Comp.Components);
     }
+    #endregion
+
+
+
+    #region CP14StatusEffectApplySpellEffectComponent
+    private void SpellEffectApply(Entity<CP14StatusEffectApplySpellEffectComponent> ent, ref CP14StatusEffectApplied args)
+    {
+        foreach (var effect in ent.Comp.StartEffect)
+        {
+            effect.Effect(EntityManager, new CP14SpellEffectBaseArgs(null, null, args.Target, Transform(args.Target).Coordinates));
+        }
+    }
+
+    private void SpellEffectRemove(Entity<CP14StatusEffectApplySpellEffectComponent> ent, ref CP14StatusEffectRemoved args)
+    {
+        foreach (var effect in ent.Comp.EndEffect)
+        {
+            effect.Effect(EntityManager, new CP14SpellEffectBaseArgs(null, null, args.Target, Transform(args.Target).Coordinates));
+        }
+    }
+
+    private void UpdateSpellEffect(float frameTime)
+    {
+        var query = EntityQueryEnumerator<CP14StatusEffectApplySpellEffectComponent, CP14StatusEffectComponent>();
+        while (query.MoveNext(out var ent, out var spellEffect, out var statusEffect))
+        {
+            if (spellEffect.NextUpdateTime > _timing.CurTime)
+                continue;
+
+            if (statusEffect.AppliedTo is null)
+                continue;
+
+            spellEffect.NextUpdateTime = _timing.CurTime + spellEffect.UpdateFrequency;
+
+            foreach (var effect in spellEffect.UpdateEffect)
+            {
+                effect.Effect(EntityManager, new CP14SpellEffectBaseArgs(null, null, statusEffect.AppliedTo, Transform(statusEffect.AppliedTo.Value).Coordinates));
+            }
+        }
+    }
+    #endregion
 }

--- a/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.cs
@@ -10,6 +10,7 @@ public sealed partial class CP14SharedStatusEffectSystem : EntitySystem
 {
     [Dependency] private readonly AlertsSystem _alerts = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly IComponentFactory _compFactory = default!;

--- a/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.cs
@@ -1,0 +1,121 @@
+using Content.Shared.Alert;
+using Robust.Shared.Serialization;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._CP14.StatusEffect;
+
+public sealed partial class CP14SharedStatusEffectSystem : EntitySystem
+{
+    [Dependency] private readonly AlertsSystem _alerts = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    private EntityQuery<CP14StatusEffectContainerComponent> _containerQuery;
+    private EntityQuery<CP14StatusEffectComponent> _effectQuery;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<CP14StatusEffectContainerComponent, ComponentShutdown>(OnContainerShutdown);
+
+        SubscribeLocalEvent<CP14StatusEffectComponent, CP14StatusEffectApplied>(OnStatusEffectApplied);
+        SubscribeLocalEvent<CP14StatusEffectComponent, CP14StatusEffectRemoved>(OnStatusEffectRemoved);
+
+        _containerQuery = GetEntityQuery<CP14StatusEffectContainerComponent>();
+        _effectQuery = GetEntityQuery<CP14StatusEffectComponent>();
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<CP14StatusEffectComponent>();
+        while (query.MoveNext(out var ent, out var effect))
+        {
+            if (effect.EndEffectTime is null)
+                continue;
+
+            if (!(_timing.CurTime >= effect.EndEffectTime))
+                continue;
+
+            if (effect.AppliedTo is null)
+                continue;
+
+            var ev = new CP14StatusEffectRemoved(effect.AppliedTo.Value, ent);
+            RaiseLocalEvent(effect.AppliedTo.Value, ev);
+            RaiseLocalEvent(ent, ev);
+
+            QueueDel(ent);
+        }
+    }
+
+    private void OnContainerShutdown(Entity<CP14StatusEffectContainerComponent> ent, ref ComponentShutdown args)
+    {
+        foreach (var effect in ent.Comp.ActiveStatusEffects)
+        {
+            QueueDel(effect.Value);
+        }
+    }
+
+    private void AddStatusEffectTime(EntityUid ent, EntityUid effect, TimeSpan duration)
+    {
+        if (!_effectQuery.TryComp(effect, out var effectComp))
+            return;
+        if (effectComp.AppliedTo is null)
+            return;
+
+        if (effectComp.Alert is not null)
+        {
+            effectComp.EndEffectTime += duration;
+            _alerts.ShowAlert(
+                effectComp.AppliedTo.Value,
+                effectComp.Alert.Value,
+                cooldown: effectComp.EndEffectTime is null ? null : (_timing.CurTime, effectComp.EndEffectTime.Value));
+        }
+    }
+
+    private void OnStatusEffectApplied(Entity<CP14StatusEffectComponent> ent, ref CP14StatusEffectApplied args)
+    {
+        if (ent.Comp.AppliedTo is null)
+            return;
+
+        if (ent.Comp.Alert is not null)
+        {
+            _alerts.ShowAlert(
+                ent.Comp.AppliedTo.Value,
+                ent.Comp.Alert.Value,
+                cooldown: ent.Comp.EndEffectTime is null ? null : (_timing.CurTime, ent.Comp.EndEffectTime.Value));
+        }
+    }
+
+    private void OnStatusEffectRemoved(Entity<CP14StatusEffectComponent> ent, ref CP14StatusEffectRemoved args)
+    {
+        if (ent.Comp.AppliedTo is null)
+            return;
+
+        if (ent.Comp.Alert is not null)
+        {
+            _alerts.ClearAlert(ent.Comp.AppliedTo.Value, ent.Comp.Alert.Value);
+        }
+    }
+}
+
+/// <summary>
+/// Calls on both effect entity and target entity, when a status effect is applied.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class CP14StatusEffectApplied(EntityUid target, EntityUid effect) : EntityEventArgs
+{
+    public EntityUid Target = target;
+    public EntityUid Effect = effect;
+}
+
+/// <summary>
+/// Calls on both effect entity and target entity, when a status effect is removed.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class CP14StatusEffectRemoved(EntityUid target, EntityUid effect) : EntityEventArgs
+{
+    public EntityUid Target = target;
+    public EntityUid Effect = effect;
+}

--- a/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.cs
@@ -37,6 +37,8 @@ public sealed partial class CP14SharedStatusEffectSystem : EntitySystem
     {
         base.Update(frameTime);
 
+        UpdateEffects(frameTime);
+
         var query = EntityQueryEnumerator<CP14StatusEffectComponent>();
         while (query.MoveNext(out var ent, out var effect))
         {

--- a/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Alert;
-using Robust.Shared.Serialization;
+using Content.Shared.Whitelist;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
 namespace Content.Shared._CP14.StatusEffect;
@@ -8,6 +9,9 @@ public sealed partial class CP14SharedStatusEffectSystem : EntitySystem
 {
     [Dependency] private readonly AlertsSystem _alerts = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly IComponentFactory _compFactory = default!;
 
     private EntityQuery<CP14StatusEffectContainerComponent> _containerQuery;
     private EntityQuery<CP14StatusEffectComponent> _effectQuery;

--- a/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.cs
@@ -41,17 +41,12 @@ public sealed partial class CP14SharedStatusEffectSystem : EntitySystem
             if (effect.AppliedTo is null)
                 continue;
 
-            var ev = new CP14StatusEffectRemoved(effect.AppliedTo.Value, ent);
-            RaiseLocalEvent(effect.AppliedTo.Value, ev);
-            RaiseLocalEvent(ent, ev);
-
-            EnsureComp<CP14StatusEffectContainerComponent>(effect.AppliedTo.Value, out var container);
-
             var meta = MetaData(ent);
-            if (meta.EntityPrototype is not null)
-                container.ActiveStatusEffects.Remove(meta.EntityPrototype);
 
-            QueueDel(ent);
+            if (meta.EntityPrototype is null)
+                continue;
+
+            TryRemoveStatusEffect(effect.AppliedTo.Value, meta.EntityPrototype);
         }
     }
 

--- a/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.cs
@@ -45,6 +45,12 @@ public sealed partial class CP14SharedStatusEffectSystem : EntitySystem
             RaiseLocalEvent(effect.AppliedTo.Value, ev);
             RaiseLocalEvent(ent, ev);
 
+            EnsureComp<CP14StatusEffectContainerComponent>(effect.AppliedTo.Value, out var container);
+
+            var meta = MetaData(ent);
+            if (meta.EntityPrototype is not null)
+                container.ActiveStatusEffects.Remove(meta.EntityPrototype);
+
             QueueDel(ent);
         }
     }
@@ -61,6 +67,7 @@ public sealed partial class CP14SharedStatusEffectSystem : EntitySystem
     {
         if (!_effectQuery.TryComp(effect, out var effectComp))
             return;
+
         if (effectComp.AppliedTo is null)
             return;
 
@@ -103,7 +110,6 @@ public sealed partial class CP14SharedStatusEffectSystem : EntitySystem
 /// <summary>
 /// Calls on both effect entity and target entity, when a status effect is applied.
 /// </summary>
-[Serializable, NetSerializable]
 public sealed class CP14StatusEffectApplied(EntityUid target, EntityUid effect) : EntityEventArgs
 {
     public EntityUid Target = target;
@@ -113,7 +119,6 @@ public sealed class CP14StatusEffectApplied(EntityUid target, EntityUid effect) 
 /// <summary>
 /// Calls on both effect entity and target entity, when a status effect is removed.
 /// </summary>
-[Serializable, NetSerializable]
 public sealed class CP14StatusEffectRemoved(EntityUid target, EntityUid effect) : EntityEventArgs
 {
     public EntityUid Target = target;

--- a/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.cs
@@ -134,17 +134,11 @@ public sealed partial class CP14SharedStatusEffectSystem : EntitySystem
 /// <summary>
 /// Calls on both effect entity and target entity, when a status effect is applied.
 /// </summary>
-public sealed class CP14StatusEffectApplied(EntityUid target, Entity<CP14StatusEffectComponent> effect) : EntityEventArgs
-{
-    public EntityUid Target = target;
-    public Entity<CP14StatusEffectComponent> Effect = effect;
-}
+[ByRefEvent]
+public readonly record struct CP14StatusEffectApplied(EntityUid Target, Entity<CP14StatusEffectComponent> Effect);
 
 /// <summary>
 /// Calls on both effect entity and target entity, when a status effect is removed.
 /// </summary>
-public sealed class CP14StatusEffectRemoved(EntityUid target, Entity<CP14StatusEffectComponent> effect) : EntityEventArgs
-{
-    public EntityUid Target = target;
-    public Entity<CP14StatusEffectComponent> Effect = effect;
-}
+[ByRefEvent]
+public readonly record struct CP14StatusEffectRemoved(EntityUid Target, Entity<CP14StatusEffectComponent> Effect);

--- a/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14SharedStatusEffectSystem.cs
@@ -20,6 +20,8 @@ public sealed partial class CP14SharedStatusEffectSystem : EntitySystem
     {
         base.Initialize();
 
+        InitializeEffects();
+
         SubscribeLocalEvent<CP14StatusEffectContainerComponent, ComponentShutdown>(OnContainerShutdown);
 
         SubscribeLocalEvent<CP14StatusEffectComponent, CP14StatusEffectApplied>(OnStatusEffectApplied);
@@ -109,17 +111,17 @@ public sealed partial class CP14SharedStatusEffectSystem : EntitySystem
 /// <summary>
 /// Calls on both effect entity and target entity, when a status effect is applied.
 /// </summary>
-public sealed class CP14StatusEffectApplied(EntityUid target, EntityUid effect) : EntityEventArgs
+public sealed class CP14StatusEffectApplied(EntityUid target, Entity<CP14StatusEffectComponent> effect) : EntityEventArgs
 {
     public EntityUid Target = target;
-    public EntityUid Effect = effect;
+    public Entity<CP14StatusEffectComponent> Effect = effect;
 }
 
 /// <summary>
 /// Calls on both effect entity and target entity, when a status effect is removed.
 /// </summary>
-public sealed class CP14StatusEffectRemoved(EntityUid target, EntityUid effect) : EntityEventArgs
+public sealed class CP14StatusEffectRemoved(EntityUid target, Entity<CP14StatusEffectComponent> effect) : EntityEventArgs
 {
     public EntityUid Target = target;
-    public EntityUid Effect = effect;
+    public Entity<CP14StatusEffectComponent> Effect = effect;
 }

--- a/Content.Shared/_CP14/StatusEffect/CP14StatusEffectAdditionalComponentsComponent.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14StatusEffectAdditionalComponentsComponent.cs
@@ -1,0 +1,27 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._CP14.StatusEffect;
+
+/// <summary>
+/// A component for a status effect entity that adds and removes components on the affected entity, at the start and end of the status effect.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(CP14SharedStatusEffectSystem))]
+public sealed partial class CP14StatusEffectAdditionalComponentsComponent : Component
+{
+    /// <summary>
+    /// Components that will be added to the status effect entity.
+    /// </summary>
+    /// <remarks>
+    /// Important: Only use components that you are sure cannot be added or removed by other systems! At least check that it won't break anything.
+    /// </remarks>
+    [DataField(required: true)]
+    public ComponentRegistry Components = new();
+
+    /// <summary>
+    /// Should we override the components of the same type that already exist on the target entity?
+    /// </summary>
+    [DataField]
+    public bool Overridde = true;
+}

--- a/Content.Shared/_CP14/StatusEffect/CP14StatusEffectApplySpellEffectComponent.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14StatusEffectApplySpellEffectComponent.cs
@@ -1,0 +1,24 @@
+using Content.Shared._CP14.MagicSpell.Spells;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._CP14.StatusEffect;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentPause]
+[Access(typeof(CP14SharedStatusEffectSystem))]
+public sealed partial class CP14StatusEffectApplySpellEffectComponent : Component
+{
+    [DataField(serverOnly: true)]
+    public List<CP14SpellEffect> StartEffect = new();
+
+    [DataField(serverOnly: true)]
+    public List<CP14SpellEffect> EndEffect = new();
+
+    [DataField(serverOnly: true)]
+    public List<CP14SpellEffect> UpdateEffect = new();
+
+    [DataField]
+    public TimeSpan UpdateFrequency = TimeSpan.FromSeconds(1f);
+
+    [DataField, AutoPausedField]
+    public TimeSpan NextUpdateTime = TimeSpan.Zero;
+}

--- a/Content.Shared/_CP14/StatusEffect/CP14StatusEffectComponent.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14StatusEffectComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Alert;
+using Content.Shared.Whitelist;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
@@ -20,4 +21,10 @@ public sealed partial class CP14StatusEffectComponent : Component
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField, AutoNetworkedField]
     public TimeSpan? EndEffectTime;
+
+    /// <summary>
+    /// Whitelist, by which it is determined whether this status effect can be imposed on a particular entity.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? Whitelist = null;
 }

--- a/Content.Shared/_CP14/StatusEffect/CP14StatusEffectComponent.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14StatusEffectComponent.cs
@@ -1,0 +1,23 @@
+using Content.Shared.Alert;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared._CP14.StatusEffect;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true), AutoGenerateComponentPause]
+[Access(typeof(CP14SharedStatusEffectSystem))]
+public sealed partial class CP14StatusEffectComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public EntityUid? AppliedTo = null;
+
+    /// <summary>
+    /// Status effect indication for the player
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public ProtoId<AlertPrototype>? Alert;
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField, AutoNetworkedField]
+    public TimeSpan? EndEffectTime;
+}

--- a/Content.Shared/_CP14/StatusEffect/CP14StatusEffectComponent.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14StatusEffectComponent.cs
@@ -36,4 +36,10 @@ public sealed partial class CP14StatusEffectComponent : Component
     /// </summary>
     [DataField]
     public EntityWhitelist? Whitelist = null;
+
+    /// <summary>
+    ///
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? Blacklist = null;
 }

--- a/Content.Shared/_CP14/StatusEffect/CP14StatusEffectComponent.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14StatusEffectComponent.cs
@@ -6,10 +6,16 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared._CP14.StatusEffect;
 
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true), AutoGenerateComponentPause]
+/// <summary>
+/// The base component for all status effects. Provides a link between the effect and the affected entity, and some data common to all status effects.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
 [Access(typeof(CP14SharedStatusEffectSystem))]
 public sealed partial class CP14StatusEffectComponent : Component
 {
+    /// <summary>
+    /// The entity that this status effect is applied to.
+    /// </summary>
     [DataField, AutoNetworkedField]
     public EntityUid? AppliedTo = null;
 
@@ -19,6 +25,9 @@ public sealed partial class CP14StatusEffectComponent : Component
     [DataField, AutoNetworkedField]
     public ProtoId<AlertPrototype>? Alert;
 
+    /// <summary>
+    /// When this effect will end.
+    /// </summary>
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField, AutoNetworkedField]
     public TimeSpan? EndEffectTime;
 

--- a/Content.Shared/_CP14/StatusEffect/CP14StatusEffectContainerComponent.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14StatusEffectContainerComponent.cs
@@ -3,6 +3,9 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared._CP14.StatusEffect;
 
+/// <summary>
+/// A component that is automatically added to any entities that have a status effect applied to them. Allows you to track which status effects are applied to an entity right now.
+/// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
 [Access(typeof(CP14SharedStatusEffectSystem))]
 public sealed partial class CP14StatusEffectContainerComponent : Component

--- a/Content.Shared/_CP14/StatusEffect/CP14StatusEffectContainerComponent.cs
+++ b/Content.Shared/_CP14/StatusEffect/CP14StatusEffectContainerComponent.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._CP14.StatusEffect;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
+[Access(typeof(CP14SharedStatusEffectSystem))]
+public sealed partial class CP14StatusEffectContainerComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public Dictionary<EntProtoId, EntityUid> ActiveStatusEffects = new();
+}

--- a/Resources/Prototypes/_CP14/Entities/StatusEffects/test.yml
+++ b/Resources/Prototypes/_CP14/Entities/StatusEffects/test.yml
@@ -11,3 +11,25 @@
   - type: CP14StatusEffectAdditionalComponents
     components:
     - type: Muted
+  - type: CP14StatusEffectApplySpellEffect
+    updateEffect:
+    - !type:CP14SpellSpawnEntityOnTarget
+      spawns:
+      - CP14ImpactEffectCureWounds
+    - !type:CP14SpellApplyEntityEffect
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Slash: -1
+            Blunt: -1
+            Piercing: -1
+      - !type:Jitter
+    endEffect:
+    - !type:CP14SpellSpawnEntityOnTarget
+      spawns:
+      - CP14ImpactEffectSheepPolymorph
+    - !type:CP14SpellApplyEntityEffect
+      effects:
+      - !type:Polymorph
+        prototype: CP14Sheep

--- a/Resources/Prototypes/_CP14/Entities/StatusEffects/test.yml
+++ b/Resources/Prototypes/_CP14/Entities/StatusEffects/test.yml
@@ -1,10 +1,13 @@
 - type: entity
   id: CP14StatusEffectTestRegeneration
-  name: Regeneration
-  description: Welp, we healing now!
+  name: WeeWooWeeWoo
+  description: Welp, we muted now!
   components:
   - type: CP14StatusEffect
     alert: CP14VampireStarving
     whitelist:
       components:
         - MobState
+  - type: CP14StatusEffectAdditionalComponents
+    components:
+    - type: Muted

--- a/Resources/Prototypes/_CP14/Entities/StatusEffects/test.yml
+++ b/Resources/Prototypes/_CP14/Entities/StatusEffects/test.yml
@@ -1,0 +1,5 @@
+- type: entity
+  id: CP14StatusEffectTestRegeneration
+  components:
+  - type: CP14StatusEffect
+    alert: CP14VampireStarving

--- a/Resources/Prototypes/_CP14/Entities/StatusEffects/test.yml
+++ b/Resources/Prototypes/_CP14/Entities/StatusEffects/test.yml
@@ -5,3 +5,6 @@
   components:
   - type: CP14StatusEffect
     alert: CP14VampireStarving
+    whitelist:
+      components:
+        - MobState

--- a/Resources/Prototypes/_CP14/Entities/StatusEffects/test.yml
+++ b/Resources/Prototypes/_CP14/Entities/StatusEffects/test.yml
@@ -1,19 +1,25 @@
 - type: entity
-  id: CP14StatusEffectTestRegeneration
-  name: WeeWooWeeWoo
-  description: Welp, we muted now!
+  id: CP14StatusEffectBase
+  abstract: true
+  components:
+  - type: Sprite
+    drawDepth: Effects
+    noRot: true
+  - type: Tag
+    tags:
+    - HideContextMenu
+
+- type: entity
+  id: CP14StatusEffectTest
+  parent: CP14StatusEffectBase
   components:
   # Visual
   - type: Sprite
-    drawDepth: Effects
     sprite: _CP14/Effects/Magic/cast_impact.rsi
     layers:
     - state: particles_down
       color: "#6c5f82"
       shader: unshaded
-  - type: Tag
-    tags:
-    - HideContextMenu
   - type: PointLight
     radius: 1.5
     energy: 2.5

--- a/Resources/Prototypes/_CP14/Entities/StatusEffects/test.yml
+++ b/Resources/Prototypes/_CP14/Entities/StatusEffects/test.yml
@@ -3,6 +3,22 @@
   name: WeeWooWeeWoo
   description: Welp, we muted now!
   components:
+  # Visual
+  - type: Sprite
+    drawDepth: Effects
+    sprite: _CP14/Effects/Magic/cast_impact.rsi
+    layers:
+    - state: particles_down
+      color: "#6c5f82"
+      shader: unshaded
+  - type: Tag
+    tags:
+    - HideContextMenu
+  - type: PointLight
+    radius: 1.5
+    energy: 2.5
+    netsync: false
+  # Logic
   - type: CP14StatusEffect
     alert: CP14VampireStarving
     whitelist:

--- a/Resources/Prototypes/_CP14/Entities/StatusEffects/test.yml
+++ b/Resources/Prototypes/_CP14/Entities/StatusEffects/test.yml
@@ -1,5 +1,7 @@
 - type: entity
   id: CP14StatusEffectTestRegeneration
+  name: Regeneration
+  description: Welp, we healing now!
   components:
   - type: CP14StatusEffect
     alert: CP14VampireStarving


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
<!-- Что вы изменили в своем пулл реквесте? -->
Итак, текущая система статусных эффектов находящаяся у Wizden МЯГКО говоря кривая, и неудобная в использовании.

Это - новая система выполняющая те же функции, но переписанная с исправлением ошибок оригинала.
В текущем варианте:
- Все статусные эффекты можно описывать полностью через прототипы
- Статусные эффекты являются энтити, и поддерживают куда более легкую ECS модификацию
- Статусные эффекты не нужно прописывать в КАЖДОМ мобе, который должен поддерживать этот эффект


Разрабатываю на CE, но если Sloth или другие мейнтейнеры Wizden посчитают эту систему нормального качества, она будет портирована в апстрим.


___

So, the current system of status effects that Wizden has is, to put it mildly, crooked and inconvenient to use.

This is a new system that performs the same functions, but rewritten to correct the errors of the original.
In the current version:

All status effects can be described entirely through prototypes
Status effects are entity, and support much lighter ECS modification.
Status effects do not need to be described in EVERY mob that needs to support the effect

Developing in CE, but if Sloth or other Wizden maintainers think this system is of okay quality, it will be ported to upstream.

TODO:
- [x] Базовая система наложения эффектов
- [x] Визуализация статусных эффектов на сущности
- [ ] Несколько простых эффектов, с использованием в заклинаниях
  - [ ] Спелл медленной регенерации
  - [ ] Спелл каменной кожи
  - [ ] Какая нить тестовая травма для меда

