### PR TITLE
Ребаланс выпадения руды

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Structures/Walls/ore_veins.yml
+++ b/Resources/Prototypes/_CP14/Entities/Structures/Walls/ore_veins.yml
@@ -29,8 +29,8 @@
       - !type:SpawnEntitiesBehavior
         spawn:
           CP14OreCopper1:
-            min: 3
-            max: 6
+            min: 4
+            max: 7
       - !type:DoActsBehavior
         acts: ["Destruction"]
 
@@ -64,7 +64,7 @@
       - !type:SpawnEntitiesBehavior
         spawn:
           CP14OreIron1:
-            min: 3
+            min: 4
             max: 6
       - !type:DoActsBehavior
         acts: ["Destruction"]

--- a/Resources/Prototypes/_CP14/Procedural/Demiplane/Modifiers/Reward/ores.yml
+++ b/Resources/Prototypes/_CP14/Procedural/Demiplane/Modifiers/Reward/ores.yml
@@ -18,8 +18,8 @@
       - CP14WallStone
       entity: CP14WallStoneIronOre
       count: 15
-      minGroupSize: 2
-      maxGroupSize: 4
+      minGroupSize: 3
+      maxGroupSize: 5
 
 - type: cp14DemiplaneModifier
   id: IronOreUnderground
@@ -39,8 +39,8 @@
       - CP14WallStone
       entity: CP14WallStoneIronOre
       count: 10
-      minGroupSize: 4
-      maxGroupSize: 6
+      minGroupSize: 5
+      maxGroupSize: 7
 
 - type: cp14DemiplaneModifier
   id: CopperOre
@@ -60,8 +60,8 @@
       - CP14WallStone
       entity: CP14WallStoneCopperOre
       count: 15
-      minGroupSize: 2
-      maxGroupSize: 4
+      minGroupSize: 3
+      maxGroupSize: 5
 
 - type: cp14DemiplaneModifier
   id: CopperOreUnderground
@@ -81,8 +81,8 @@
       - CP14WallStone
       entity: CP14WallStoneCopperOre
       count: 10
-      minGroupSize: 4
-      maxGroupSize: 6
+      minGroupSize: 5
+      maxGroupSize: 7
 
 # TIER 2
 
@@ -104,7 +104,7 @@
       - CP14WallStone
       entity: CP14WallStoneGoldOre
       count: 10
-      minGroupSize: 2
+      minGroupSize: 3
       maxGroupSize: 4
 
 - type: cp14DemiplaneModifier
@@ -125,7 +125,7 @@
       - CP14WallStone
       entity: CP14WallStoneGoldOre
       count: 15
-      minGroupSize: 2
+      minGroupSize: 3
       maxGroupSize: 4
 
 - type: cp14DemiplaneModifier
@@ -146,7 +146,7 @@
       - CP14WallStone
       entity: CP14WallStoneMithrilOre 
       count: 10
-      minGroupSize: 2
+      minGroupSize: 3
       maxGroupSize: 4
 
 - type: cp14DemiplaneModifier
@@ -167,5 +167,5 @@
       - CP14WallStone
       entity: CP14WallStoneMithrilOre 
       count: 15
-      minGroupSize: 2
+      minGroupSize: 3
       maxGroupSize: 4

--- a/Resources/Prototypes/_CP14/Procedural/Demiplane/Modifiers/Reward/ores.yml
+++ b/Resources/Prototypes/_CP14/Procedural/Demiplane/Modifiers/Reward/ores.yml
@@ -18,8 +18,8 @@
       - CP14WallStone
       entity: CP14WallStoneIronOre
       count: 15
-      minGroupSize: 3
-      maxGroupSize: 5
+      minGroupSize: 2
+      maxGroupSize: 4
 
 - type: cp14DemiplaneModifier
   id: IronOreUnderground
@@ -39,8 +39,8 @@
       - CP14WallStone
       entity: CP14WallStoneIronOre
       count: 10
-      minGroupSize: 5
-      maxGroupSize: 7
+      minGroupSize: 4
+      maxGroupSize: 6
 
 - type: cp14DemiplaneModifier
   id: CopperOre
@@ -60,8 +60,8 @@
       - CP14WallStone
       entity: CP14WallStoneCopperOre
       count: 15
-      minGroupSize: 3
-      maxGroupSize: 5
+      minGroupSize: 2
+      maxGroupSize: 4
 
 - type: cp14DemiplaneModifier
   id: CopperOreUnderground
@@ -81,8 +81,8 @@
       - CP14WallStone
       entity: CP14WallStoneCopperOre
       count: 10
-      minGroupSize: 5
-      maxGroupSize: 7
+      minGroupSize: 4
+      maxGroupSize: 6
 
 # TIER 2
 
@@ -104,7 +104,7 @@
       - CP14WallStone
       entity: CP14WallStoneGoldOre
       count: 10
-      minGroupSize: 3
+      minGroupSize: 2
       maxGroupSize: 4
 
 - type: cp14DemiplaneModifier
@@ -125,7 +125,7 @@
       - CP14WallStone
       entity: CP14WallStoneGoldOre
       count: 15
-      minGroupSize: 3
+      minGroupSize: 2
       maxGroupSize: 4
 
 - type: cp14DemiplaneModifier
@@ -146,7 +146,7 @@
       - CP14WallStone
       entity: CP14WallStoneMithrilOre 
       count: 10
-      minGroupSize: 3
+      minGroupSize: 2
       maxGroupSize: 4
 
 - type: cp14DemiplaneModifier
@@ -167,5 +167,5 @@
       - CP14WallStone
       entity: CP14WallStoneMithrilOre 
       count: 15
-      minGroupSize: 3
+      minGroupSize: 2
       maxGroupSize: 4


### PR DESCRIPTION
## About the PR

Теперь выпадает немного больше медной и железной руды, а так же увелчино количество возможного спавна рудных стен в каменных жилах

## Why / Balance

После изменения баланса количества жил и руды в ней, в целом руды стало намного меньше, что редко окупает поход в демиплан или вообще идет в минус. 
