### PR TITLE
Species free innate skill

### DIFF
--- a/Content.Client/_CP14/UserInterface/Systems/Skill/CP14SkillUIController.cs
+++ b/Content.Client/_CP14/UserInterface/Systems/Skill/CP14SkillUIController.cs
@@ -136,7 +136,7 @@ public sealed class CP14SkillUIController : UIController, IOnStateEntered<Gamepl
         if (_window is null)
             return;
 
-        if (_playerManager.LocalEntity == null)
+        if (_targetPlayer == null)
             return;
 
         if (node == null)
@@ -159,7 +159,7 @@ public sealed class CP14SkillUIController : UIController, IOnStateEntered<Gamepl
         if (_window is null)
             return;
 
-        if (_playerManager.LocalEntity == null)
+        if (_targetPlayer == null)
             return;
 
         _selectedSkill = skill;
@@ -172,8 +172,9 @@ public sealed class CP14SkillUIController : UIController, IOnStateEntered<Gamepl
         {
             _window.SkillName.Text = _skill.GetSkillName(skill);
             _window.SkillDescription.SetMessage(GetSkillDescription(skill));
+            _window.SkillFree.Visible = _skill.HaveFreeSkill(_targetPlayer.Value, skill);
             _window.SkillView.Texture = skill.Icon.Frame0();
-            _window.LearnButton.Disabled = !_skill.CanLearnSkill(_playerManager.LocalEntity.Value, skill);
+            _window.LearnButton.Disabled = !_skill.CanLearnSkill(_targetPlayer.Value, skill);
             _window.SkillCost.Text = skill.LearnCost.ToString();
         }
 
@@ -187,6 +188,7 @@ public sealed class CP14SkillUIController : UIController, IOnStateEntered<Gamepl
 
         _window.SkillName.Text = string.Empty;
         _window.SkillDescription.Text = string.Empty;
+        _window.SkillFree.Visible = false;
         _window.SkillView.Texture = null;
         _window.LearnButton.Disabled = true;
     }
@@ -195,7 +197,7 @@ public sealed class CP14SkillUIController : UIController, IOnStateEntered<Gamepl
     {
         var msg = new FormattedMessage();
 
-        if (_playerManager.LocalEntity == null)
+        if (_targetPlayer == null)
             return msg;
 
         var sb = new StringBuilder();
@@ -206,7 +208,7 @@ public sealed class CP14SkillUIController : UIController, IOnStateEntered<Gamepl
         //Restrictions
         foreach (var req in skill.Restrictions)
         {
-            var color = req.Check(_entManager, _playerManager.LocalEntity.Value, skill) ? "green" : "red";
+            var color = req.Check(_entManager, _targetPlayer.Value, skill) ? "green" : "red";
 
             sb.Append($"- [color={color}]{req.GetDescription(_entManager, _proto)}[/color]\n");
         }
@@ -310,6 +312,8 @@ public sealed class CP14SkillUIController : UIController, IOnStateEntered<Gamepl
                 //TODO: Loop indexing each skill is bad
                 if (_proto.TryIndex(skillId, out var skill) && skill.Tree == tree)
                 {
+                    if (_skill.HaveFreeSkill(_targetPlayer.Value, skillId))
+                        continue;
                     learnedPoints += skill.LearnCost;
                 }
             }

--- a/Content.Client/_CP14/UserInterface/Systems/Skill/CP14SkillUIController.cs
+++ b/Content.Client/_CP14/UserInterface/Systems/Skill/CP14SkillUIController.cs
@@ -205,12 +205,15 @@ public sealed class CP14SkillUIController : UIController, IOnStateEntered<Gamepl
         //Description
         sb.Append(_skill.GetSkillDescription(skill) + "\n \n");
 
-        //Restrictions
-        foreach (var req in skill.Restrictions)
+        if (!_skill.HaveSkill(_targetPlayer.Value, skill))
         {
-            var color = req.Check(_entManager, _targetPlayer.Value, skill) ? "green" : "red";
+            //Restrictions
+            foreach (var req in skill.Restrictions)
+            {
+                var color = req.Check(_entManager, _targetPlayer.Value, skill) ? "green" : "red";
 
-            sb.Append($"- [color={color}]{req.GetDescription(_entManager, _proto)}[/color]\n");
+                sb.Append($"- [color={color}]{req.GetDescription(_entManager, _proto)}[/color]\n");
+            }
         }
 
         msg.TryAddMarkup(sb.ToString(), out _);

--- a/Content.Client/_CP14/UserInterface/Systems/Skill/Window/CP14SkillWindow.xaml
+++ b/Content.Client/_CP14/UserInterface/Systems/Skill/Window/CP14SkillWindow.xaml
@@ -45,6 +45,9 @@
                             <BoxContainer HorizontalExpand="True">
                                 <RichTextLabel Name="SkillDescription" HorizontalExpand="True" Access="Public"/>
                             </BoxContainer>
+                            <BoxContainer HorizontalExpand="True">
+                                <RichTextLabel Name="SkillFree" Text="{Loc 'cp14-skill-menu-free'}" HorizontalExpand="True" Access="Public" Visible="False"/>
+                            </BoxContainer>
                         </BoxContainer>
                     </BoxContainer>
                 </ScrollContainer>

--- a/Content.Shared/Preferences/Loadouts/LoadoutPrototype.cs
+++ b/Content.Shared/Preferences/Loadouts/LoadoutPrototype.cs
@@ -48,13 +48,7 @@ public sealed partial class LoadoutPrototype : IPrototype, IEquipmentLoadout
     public Dictionary<string, List<EntProtoId>> Storage { get; set; } = new();
 
     /// <summary>
-    /// CP14 - it is possible to give action spells or spells to players who have taken this loadout
-    /// </summary>
-    [DataField]
-    public List<EntProtoId> Actions { get; set; } = new();
-
-    /// <summary>
-    /// CP14 - it is possible to give skill trees to players who have taken this loadout
+    /// CP14 - it is possible to give free skills to players
     /// </summary>
     [DataField]
     public HashSet<ProtoId<CP14SkillPrototype>> Skills = new();

--- a/Content.Shared/Station/SharedStationSpawningSystem.cs
+++ b/Content.Shared/Station/SharedStationSpawningSystem.cs
@@ -97,14 +97,9 @@ public abstract class SharedStationSpawningSystem : EntitySystem
 
     private void CP14EquipStartingActions(EntityUid entity, LoadoutPrototype loadout)
     {
-        foreach (var action in loadout.Actions)
-        {
-            _action.AddAction(entity, action);
-        }
-
         foreach (var skill in loadout.Skills)
         {
-            _skill.TryAddSkill(entity, skill);
+            _skill.TryAddSkill(entity, skill, free: true);
         }
     }
 

--- a/Content.Shared/_CP14/Skill/CP14LearnSkillsSpecial.cs
+++ b/Content.Shared/_CP14/Skill/CP14LearnSkillsSpecial.cs
@@ -16,7 +16,7 @@ public sealed partial class CP14LearnSkillsSpecial : JobSpecial
 
         foreach (var skill in Skills)
         {
-            skillSys.TryAddSkill(mob, skill);
+            skillSys.TryAddSkill(mob, skill, free: true);
         }
     }
 }

--- a/Content.Shared/_CP14/Skill/CP14SharedSkillSystem.cs
+++ b/Content.Shared/_CP14/Skill/CP14SharedSkillSystem.cs
@@ -26,7 +26,8 @@ public abstract partial class CP14SharedSkillSystem : EntitySystem
     /// </summary>
     public bool TryAddSkill(EntityUid target,
         ProtoId<CP14SkillPrototype> skill,
-        CP14SkillStorageComponent? component = null)
+        CP14SkillStorageComponent? component = null,
+        bool free = false)
     {
         if (!Resolve(target, ref component, false))
             return false;
@@ -42,7 +43,10 @@ public abstract partial class CP14SharedSkillSystem : EntitySystem
             effect.AddSkill(EntityManager, target);
         }
 
-        component.SkillsSumExperience += indexedSkill.LearnCost;
+        if (free)
+            component.FreeLearnedSkills.Add(skill);
+        else
+            component.SkillsSumExperience += indexedSkill.LearnCost;
 
         component.LearnedSkills.Add(skill);
         Dirty(target, component);
@@ -74,7 +78,8 @@ public abstract partial class CP14SharedSkillSystem : EntitySystem
             effect.RemoveSkill(EntityManager, target);
         }
 
-        component.SkillsSumExperience -= indexedSkill.LearnCost;
+        if (!component.FreeLearnedSkills.Remove(skill))
+            component.SkillsSumExperience -= indexedSkill.LearnCost;
 
         Dirty(target, component);
         return true;
@@ -91,6 +96,16 @@ public abstract partial class CP14SharedSkillSystem : EntitySystem
             return false;
 
         return component.LearnedSkills.Contains(skill);
+    }
+
+    public bool HaveFreeSkill(EntityUid target,
+        ProtoId<CP14SkillPrototype> skill,
+        CP14SkillStorageComponent? component = null)
+    {
+        if (!Resolve(target, ref component, false))
+            return false;
+
+        return component.FreeLearnedSkills.Contains(skill);
     }
 
     /// <summary>

--- a/Content.Shared/_CP14/Skill/CP14SharedSkillSystem.cs
+++ b/Content.Shared/_CP14/Skill/CP14SharedSkillSystem.cs
@@ -17,8 +17,31 @@ public abstract partial class CP14SharedSkillSystem : EntitySystem
 
         _skillStorageQuery = GetEntityQuery<CP14SkillStorageComponent>();
 
+        SubscribeLocalEvent<CP14SkillStorageComponent, MapInitEvent>(OnMapInit);
+
         InitializeAdmin();
         InitializeChecks();
+    }
+
+    private void OnMapInit(Entity<CP14SkillStorageComponent> ent, ref MapInitEvent args)
+    {
+        //If at initialization we have any skill records, we automatically give them to this entity
+
+        var free = ent.Comp.FreeLearnedSkills.ToList();
+        var learned = ent.Comp.LearnedSkills.ToList();
+
+        ent.Comp.FreeLearnedSkills.Clear();
+        ent.Comp.LearnedSkills.Clear();
+
+        foreach (var skill in free)
+        {
+            TryAddSkill(ent.Owner, skill, ent.Comp, true);
+        }
+
+        foreach (var skill in learned)
+        {
+            TryAddSkill(ent.Owner, skill, ent.Comp);
+        }
     }
 
     /// <summary>

--- a/Content.Shared/_CP14/Skill/Components/CP14SkillStorageComponent.cs
+++ b/Content.Shared/_CP14/Skill/Components/CP14SkillStorageComponent.cs
@@ -14,6 +14,13 @@ namespace Content.Shared._CP14.Skill.Components;
 [Access(typeof(CP14SharedSkillSystem), typeof(CP14SharedResearchSystem))]
 public sealed partial class CP14SkillStorageComponent : Component
 {
+    /// <summary>
+    /// Tracks skills that are learned without spending memory points.
+    /// the skills that are here are DUBLED in the LearnedSkills, 
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public List<ProtoId<CP14SkillPrototype>> FreeLearnedSkills = new();
+
     [DataField, AutoNetworkedField]
     public List<ProtoId<CP14SkillPrototype>> LearnedSkills = new();
 

--- a/Resources/Locale/en-US/_CP14/skill/ui.ftl
+++ b/Resources/Locale/en-US/_CP14/skill/ui.ftl
@@ -7,6 +7,7 @@ cp14-game-hud-open-skill-menu-button-tooltip = Skill tree
 cp14-skill-menu-learn-button = Learn skill
 cp14-skill-menu-learncost = [color=yellow]Memory required:[/color]
 cp14-skill-menu-level = Memory:
+cp14-skill-menu-free = [color=green]This skill is innate to your pesonage, and wastes no memory points![/color]
 
 cp14-research-table-title = Research table
 cp14-research-recipe-list = Research costs:

--- a/Resources/Locale/en-US/_CP14/skill/ui.ftl
+++ b/Resources/Locale/en-US/_CP14/skill/ui.ftl
@@ -7,7 +7,7 @@ cp14-game-hud-open-skill-menu-button-tooltip = Skill tree
 cp14-skill-menu-learn-button = Learn skill
 cp14-skill-menu-learncost = [color=yellow]Memory required:[/color]
 cp14-skill-menu-level = Memory:
-cp14-skill-menu-free = [color=green]This skill is innate to your pesonage, and wastes no memory points![/color]
+cp14-skill-menu-free = [color=green]This skill is innate to your character, and wastes no memory points![/color]
 
 cp14-research-table-title = Research table
 cp14-research-recipe-list = Research costs:

--- a/Resources/Locale/ru-RU/_CP14/skill/ui.ftl
+++ b/Resources/Locale/ru-RU/_CP14/skill/ui.ftl
@@ -7,7 +7,7 @@ cp14-game-hud-open-skill-menu-button-tooltip = Деревья навыков
 cp14-skill-menu-learn-button = Изучить навык
 cp14-skill-menu-learncost = [color=yellow]Требуется памяти:[/color]
 cp14-skill-menu-level = Память:
-cp14-skill-menu-free = [color=green]Этот навык врожденный для вашего песонажа, и не тратит очков памяти![/color]
+cp14-skill-menu-free = [color=green]Этот навык врожденный для вашего персонажа, и не тратит очков памяти![/color]
 
 cp14-research-table-title = Стол исследований
 cp14-research-recipe-list = Затраты на исследование:

--- a/Resources/Locale/ru-RU/_CP14/skill/ui.ftl
+++ b/Resources/Locale/ru-RU/_CP14/skill/ui.ftl
@@ -7,6 +7,7 @@ cp14-game-hud-open-skill-menu-button-tooltip = Деревья навыков
 cp14-skill-menu-learn-button = Изучить навык
 cp14-skill-menu-learncost = [color=yellow]Требуется памяти:[/color]
 cp14-skill-menu-level = Память:
+cp14-skill-menu-free = [color=green]Этот навык врожденный для вашего песонажа, и не тратит очков памяти![/color]
 
 cp14-research-table-title = Стол исследований
 cp14-research-recipe-list = Затраты на исследование:

--- a/Resources/Prototypes/_CP14/Entities/Mobs/Species/elf.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/Species/elf.yml
@@ -41,6 +41,10 @@
   - type: CP14MagicEnergyDraw #Half of standard mana regeneration
     energy: 0.5
     delay: 3
+  - type: CP14SkillStorage #Innate metamagic
+    freeLearnedSkills:
+    - MetamagicT1
+    - MetamagicT2
   - type: Inventory
     templateId: CP14Human
     displacements:

--- a/Resources/Prototypes/_CP14/Entities/Mobs/Species/silva.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/Species/silva.yml
@@ -73,6 +73,10 @@
     spawned:
       - id: CP14FoodMeatHuman # Replace it with silva meat, heh.
         amount: 5
+  - type: CP14SkillStorage #Innate vivification
+    freeLearnedSkills:
+    - HealingT1
+    - HealingT2
   - type: CP14MagicEnergyPhotosynthesis # Silva special feature #Disabled until sunlight fixed
   - type: CP14MagicEnergyDraw #Enabled default mana regen until sunlight fixed
     enable: false

--- a/Resources/Prototypes/_CP14/Entities/Mobs/Species/tiefling.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/Species/tiefling.yml
@@ -44,10 +44,6 @@
     damage:
       Heat: 1 #Magic regen from fire
       Cold: -1
-  - type: CP14MagicManacostModify
-    globalModifier: 1.2
-    modifiers:
-      Fire: 0.5
   - type: CP14SkillStorage #Innate pyrokinetic
     freeLearnedSkills:
     - PyrokineticT1

--- a/Resources/Prototypes/_CP14/Entities/Mobs/Species/tiefling.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/Species/tiefling.yml
@@ -48,10 +48,10 @@
     globalModifier: 1.2
     modifiers:
       Fire: 0.5
-  - type: CP14SpellStorage
-    #grantAccessToSelf: true
-    #spells:
-    #- CP14ActionSpellTieflingInnerFire
+  - type: CP14SkillStorage #Innate pyrokinetic
+    freeLearnedSkills:
+    - PyrokineticT1
+    - PyrokineticT2
   - type: Inventory
     templateId: CP14Human
     femaleDisplacements:

--- a/Resources/Prototypes/_CP14/Loadouts/Jobs/guard.yml
+++ b/Resources/Prototypes/_CP14/Loadouts/Jobs/guard.yml
@@ -58,17 +58,3 @@
   id: CP14ClothingShirtGuardsChainmailShirtB
   equipment:
     shirt: CP14ClothingShirtGuardsChainmailShirtB
-
-# Spells
-
-- type: loadoutGroup
-  id: CP14GuardSpells
-  name: cp14-loadout-guard-spells
-  loadouts:
-  - CP14ActionSpellFlashLight
-
-- type: loadout
-  id: CP14ActionSpellFlashLight
-  dummyEntity: CP14ActionSpellFlashLight
-  actions:
-  - CP14ActionSpellFlashLight

--- a/Resources/Prototypes/_CP14/Loadouts/Jobs/guildmaster.yml
+++ b/Resources/Prototypes/_CP14/Loadouts/Jobs/guildmaster.yml
@@ -67,26 +67,3 @@
   name: cp14-loadout-guildmaster-shoes
   loadouts:
   - CP14ShoesAristocraticBlack
-
-# Spells
-
-- type: loadoutGroup
-  id: CP14GuildmasterSpells
-  name: cp14-loadout-guildmaster-spells
-  minLimit: 2
-  maxLimit: 2
-  loadouts:
-  - CP14ActionSpellDemiplaneInfiltration
-  - CP14ActionSpellMonolithWarp
-
-- type: loadout
-  id: CP14ActionSpellDemiplaneInfiltration
-  dummyEntity: CP14ActionSpellDemiplaneInfiltration
-  actions:
-  - CP14ActionSpellDemiplaneInfiltration
-
-- type: loadout
-  id: CP14ActionSpellMonolithWarp
-  dummyEntity: CP14ActionSpellMonolithWarp
-  actions:
-  - CP14ActionSpellMonolithWarp

--- a/Resources/Prototypes/_CP14/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_CP14/Loadouts/role_loadouts.yml
@@ -85,7 +85,6 @@
   - CP14GeneralShoes
   - CP14GeneralBack
   - CP14GeneralTrinkets
-  - CP14GuardSpells
 
 - type: roleLoadout
   id: JobCP14Guard
@@ -100,7 +99,6 @@
   - CP14GeneralShoes
   - CP14GeneralBack
   - CP14GeneralTrinkets
-  - CP14GuardSpells
 
 - type: roleLoadout
   id: JobCP14Commandant
@@ -125,7 +123,6 @@
   - CP14GuildmasterShoes
   - CP14GeneralBack
   - CP14GeneralTrinkets
-  - CP14GuildmasterSpells
 
 - type: roleLoadout
   id: JobCP14Merchant

--- a/Resources/Prototypes/_CP14/Skill/blacksmithing.yml
+++ b/Resources/Prototypes/_CP14/Skill/blacksmithing.yml
@@ -1,69 +1,68 @@
 - type: cp14Skill
   id: CopperMelting
-  skillUiPosition: 0, 0
+  skillUiPosition: 1, 0
   tree: Blacksmithing
   name: cp14-skill-copper-melt-name
-  learnCost: 0
+  learnCost: 0.5
   icon:
     sprite: _CP14/Objects/Materials/copper_ore.rsi
     state: ore3
-  restrictions:
-  - !type:Impossible
   effects:
   - !type:UnlockRecipes
 
 - type: cp14Skill
   id: IronMelting
-  skillUiPosition: 0, 2
+  skillUiPosition: 1, 2
   tree: Blacksmithing
   name: cp14-skill-iron-melt-name
-  learnCost: 0
+  learnCost: 0.5
   icon:
     sprite: _CP14/Objects/Materials/iron_ore.rsi
     state: ore3
-  restrictions:
-  - !type:Impossible
   effects:
   - !type:UnlockRecipes
+  restrictions:
+  - !type:NeedPrerequisite
+    prerequisite: CopperMelting
 
 - type: cp14Skill
   id: GoldMelting
   skillUiPosition: 0, 4
   tree: Blacksmithing
   name: cp14-skill-gold-melt-name
-  learnCost: 0
+  learnCost: 0.5
   icon:
     sprite: _CP14/Objects/Materials/gold_ore.rsi
     state: ore3
-  restrictions:
-  - !type:Impossible
   effects:
   - !type:UnlockRecipes
+  restrictions:
+  - !type:NeedPrerequisite
+    prerequisite: IronMelting
 
 - type: cp14Skill
   id: MithrilMelting
-  skillUiPosition: 0, 6
+  skillUiPosition: 2, 4
   tree: Blacksmithing
   name: cp14-skill-mithril-melt-name
-  learnCost: 0
+  learnCost: 0.5
   icon:
     sprite: _CP14/Objects/Materials/mithril_ore.rsi
     state: ore3
-  restrictions:
-  - !type:Impossible
   effects:
   - !type:UnlockRecipes
+  restrictions:
+  - !type:NeedPrerequisite
+    prerequisite: IronMelting
 
 - type: cp14Skill
   id: GlassMelting
-  skillUiPosition: 2, 0
+  skillUiPosition: 3, 0
   tree: Blacksmithing
   name: cp14-skill-glass-melt-name
-  learnCost: 0
+  learnCost: 0.5
   icon:
     sprite: _CP14/Objects/Materials/glass.rsi
     state: glass_3
-  restrictions:
-  - !type:Impossible
   effects:
   - !type:UnlockRecipes

--- a/Resources/Prototypes/_CP14/Skill/hydrosophistry.yml
+++ b/Resources/Prototypes/_CP14/Skill/hydrosophistry.yml
@@ -12,7 +12,7 @@
 
 - type: cp14Skill
   id: CP14ActionSpellWaterCreation
-  skillUiPosition: 0, 4
+  skillUiPosition: 1, 4
   tree: Hydrosophistry
   icon:
     sprite: _CP14/Actions/Spells/water.rsi
@@ -26,8 +26,9 @@
 
 - type: cp14Skill
   id: CP14ActionSpellBeerCreation
-  skillUiPosition: 2, 4
+  skillUiPosition: 1, 8
   tree: Hydrosophistry
+  learnCost: 0
   icon:
     sprite: _CP14/Actions/Spells/water.rsi
     state: beer_creation
@@ -36,23 +37,9 @@
     action: CP14ActionSpellBeerCreation
   restrictions:
   - !type:NeedPrerequisite
-    prerequisite: HydrosophistryT1
+    prerequisite: CP14ActionSpellWaterCreation
   - !type:SpeciesWhitelist
     species: CP14Dwarf
-
-- type: cp14Skill
-  id: CP14ActionSpellIceShards
-  skillUiPosition: 2, 6
-  tree: Hydrosophistry
-  icon:
-    sprite: _CP14/Actions/Spells/water.rsi
-    state: ice_shards
-  effects: 
-  - !type:AddAction
-    action: CP14ActionSpellIceShards
-  restrictions:
-  - !type:NeedPrerequisite
-    prerequisite: HydrosophistryT1
 
 - type: cp14Skill
   id: CP14ActionSpellIceDagger
@@ -70,7 +57,7 @@
 
 - type: cp14Skill
   id: CP14ActionSpellIceArrow
-  skillUiPosition: 0, 8
+  skillUiPosition: 2, 6
   tree: Hydrosophistry
   icon:
     sprite: _CP14/Actions/Spells/water.rsi
@@ -110,6 +97,20 @@
   effects: 
   - !type:AddAction
     action: CP14ActionSpellFreeze
+  restrictions:
+  - !type:NeedPrerequisite
+    prerequisite: HydrosophistryT2
+
+- type: cp14Skill
+  id: CP14ActionSpellIceShards
+  skillUiPosition: 8, 4
+  tree: Hydrosophistry
+  icon:
+    sprite: _CP14/Actions/Spells/water.rsi
+    state: ice_shards
+  effects: 
+  - !type:AddAction
+    action: CP14ActionSpellIceShards
   restrictions:
   - !type:NeedPrerequisite
     prerequisite: HydrosophistryT2

--- a/Resources/Prototypes/_CP14/Skill/martial_arts.yml
+++ b/Resources/Prototypes/_CP14/Skill/martial_arts.yml
@@ -3,36 +3,30 @@
   skillUiPosition: 0, 0
   name: cp14-skill-sword-mastery-name
   desc: cp14-skill-mastery-desc
-  learnCost: 0
+  learnCost: 0.5
   tree: MartialArts
   icon: 
     sprite: _CP14/Objects/ModularTools/Blade/Sword/metall_sword.rsi
     state: preview
-  restrictions:
-  - !type:Impossible
 
 - type: cp14Skill
   id: RapierMastery
   skillUiPosition: 2, 0
   name: cp14-skill-parier-mastery-name
   desc: cp14-skill-mastery-desc
-  learnCost: 0
+  learnCost: 0.5
   tree: MartialArts
   icon: 
     sprite: _CP14/Objects/ModularTools/Blade/Rapier/metall_rapier.rsi
     state: preview
-  restrictions:
-  - !type:Impossible
 
 - type: cp14Skill
   id: SkimitarMastery
   skillUiPosition: 4, 0
   name: cp14-skill-skimitar-mastery-name
   desc: cp14-skill-mastery-desc
-  learnCost: 0
+  learnCost: 0.5
   tree: MartialArts
   icon: 
     sprite: _CP14/Objects/ModularTools/Blade/Skimitar/metall_skimitar.rsi
     state: preview
-  restrictions:
-  - !type:Impossible

--- a/Resources/Prototypes/_CP14/Skill/thaumaturgy.yml
+++ b/Resources/Prototypes/_CP14/Skill/thaumaturgy.yml
@@ -4,7 +4,7 @@
   tree: Thaumaturgy
   name: cp14-skill-alchemy-vision-name
   desc: cp14-skill-alchemy-vision-desc
-  learnCost: 0
+  learnCost: 1
   icon:
     sprite: _CP14/Clothing/Eyes/alchemy_glasses.rsi
     state: icon
@@ -12,5 +12,3 @@
   - !type:AddComponents
     components:
     - type: SolutionScanner
-  restrictions:
-  - !type:Impossible


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
<!-- Что вы изменили в своем пулл реквесте? -->
Скиллы теперь могут быть "врожденными" и не учитываться в рассчетах потраченных очков памяти.
"Врожденные" скиллы теперь могут идти от трех источников:
- Расы: 
  - Тифлинги получили Т1 и Т2 пирокинетику бесплатно
  - Сильвы получили Т1 и Т2 жизнетворения
  - Эльфы получили Т1 и Т2 метамагию
- Лоадаут
  - Авантюристы могут выбирать стартовую экипировку оружия, что дает врожденное владение им
- Роли
  - Кузнец имеет бесплатно все скиллы кузнечного дела
  - Алхимик имеет бесплатное алхимическое зрения
  - Подмастерье имеет часть кузнечных навыков и алхимическое зрение

Все навыки которые раньше нельзя было изучить (мастерство оружия, кузнечное дело, алхимия) теперь можно изучать за очки памяти

--- 

  Skills can now be “innate” and not counted in the calculation of memory points spent.
“Innate” skills can now come from three sources:
- Race: 
  - Tieflings gained T1 and T2 pyrokinetics for free
  - Sylves have received T1 and T2 vivification
  - Elves got T1 and T2 metamagic
- Loadout
  - Adventurers can choose a starting weapon loadout that grants innate weapon proficiency
- Roles
  - Blacksmith has free all blacksmithing skills
  - Alchemist has free alchemical vision
  - Apprentice has part of the blacksmithing skills and alchemical vision
  
  All skills that could not be learned before (weapons mastery, blacksmithing, alchemy) can now be learned for memory points