### PR TITLE
Tavernkeeper's Sandwich

### DIFF
--- a/Resources/Locale/en-US/_CP14/nutrition/food-sequence.ftl
+++ b/Resources/Locale/en-US/_CP14/nutrition/food-sequence.ftl
@@ -2,3 +2,7 @@
 
 cp14-food-sequence-content-pumpkin = pumpkin
 cp14-food-sequence-content-cucumber = cucumber
+
+# SANDWICH
+
+cp14-food-sequence-sandwich-gen = sandwich with {$content}

--- a/Resources/Locale/en-US/_CP14/nutrition/food-sequence.ftl
+++ b/Resources/Locale/en-US/_CP14/nutrition/food-sequence.ftl
@@ -1,0 +1,4 @@
+# GENERAL
+
+cp14-food-sequence-content-pumpkin = pumpkin
+cp14-food-sequence-content-cucumber = cucumber

--- a/Resources/Locale/ru-RU/_CP14/nutrition/food-sequence.ftl
+++ b/Resources/Locale/ru-RU/_CP14/nutrition/food-sequence.ftl
@@ -2,3 +2,7 @@
 
 cp14-food-sequence-content-pumpkin = тыква
 cp14-food-sequence-content-cucumber = огурец
+
+# SANDWICH
+
+cp14-food-sequence-sandwich-gen = бутерброд с {$content}

--- a/Resources/Locale/ru-RU/_CP14/nutrition/food-sequence.ftl
+++ b/Resources/Locale/ru-RU/_CP14/nutrition/food-sequence.ftl
@@ -1,0 +1,4 @@
+# GENERAL
+
+cp14-food-sequence-content-pumpkin = тыква
+cp14-food-sequence-content-cucumber = огурец

--- a/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/cheese.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/cheese.yml
@@ -91,4 +91,4 @@
           Quantity: 1.4
   - type: FoodSequenceElement
     entries:
-      Sandwich: CP14CheeseSandwich
+      CP14Sandwich: CP14CheeseSandwich

--- a/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/cheese.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/cheese.yml
@@ -89,3 +89,6 @@
         reagents:
         - ReagentId: Nutriment
           Quantity: 1.4
+  - type: FoodSequenceElement
+    entries:
+      Burger: CP14CheeseBurger

--- a/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/cheese.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/cheese.yml
@@ -91,4 +91,4 @@
           Quantity: 1.4
   - type: FoodSequenceElement
     entries:
-      Burger: CP14CheeseBurger
+      Sandwich: CP14CheeseSandwich

--- a/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/dough.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/dough.yml
@@ -157,6 +157,7 @@
     minLayerOffset: -0.05, 0
     maxLayerOffset: 0.05, 0
     nameGeneration: cp14-food-sequence-sandwich-gen
+    contentSeparator: ", "
   - type: Appearance
   - type: FoodMetamorphableByAdding
   - type: SolutionContainerManager

--- a/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/dough.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/dough.yml
@@ -150,7 +150,7 @@
     - state: bun_cooked_slice_bottom
     - map: ["foodSequenceLayers"]
   - type: FoodSequenceStartPoint
-    key: Sandwich
+    key: CP14Sandwich
     maxLayers: 5
     startPosition: 0, 0
     offset: 0, 0.07
@@ -195,7 +195,7 @@
           Quantity: 0.25
   - type: FoodSequenceElement
     entries:
-      Sandwich: CP14BunTopSandwich
+      CP14Sandwich: CP14BunTopSandwich
   - type: CP14TemperatureTransformation
     entries:
     - temperatureRange: 400, 500

--- a/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/dough.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/dough.yml
@@ -150,13 +150,13 @@
     - state: bun_cooked_slice_bottom
     - map: ["foodSequenceLayers"]
   - type: FoodSequenceStartPoint
-    key: Burger
+    key: Sandwich
     maxLayers: 5
     startPosition: 0, 0
     offset: 0, 0.07
     minLayerOffset: -0.05, 0
     maxLayerOffset: 0.05, 0
-    nameGeneration: food-sequence-burger-gen
+    nameGeneration: cp14-food-sequence-sandwich-gen
   - type: Appearance
   - type: FoodMetamorphableByAdding
   - type: SolutionContainerManager
@@ -194,7 +194,7 @@
           Quantity: 0.25
   - type: FoodSequenceElement
     entries:
-      Burger: CP14BunTopBurger
+      Sandwich: CP14BunTopSandwich
   - type: CP14TemperatureTransformation
     entries:
     - temperatureRange: 400, 500

--- a/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/dough.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/dough.yml
@@ -146,11 +146,24 @@
   components:
   - type: Sprite
     sprite: _CP14/Objects/Consumable/Food/dough.rsi
-    state: bun_cooked_slice_bottom
+    layers:
+    - state: bun_cooked_slice_bottom
+    - map: ["foodSequenceLayers"]
+  - type: FoodSequenceStartPoint
+    key: Burger
+    maxLayers: 5
+    startPosition: 0, 0
+    offset: 0, 0.07
+    minLayerOffset: -0.05, 0
+    maxLayerOffset: 0.05, 0
+    nameGeneration: food-sequence-burger-gen
+  - type: Appearance
+  - type: FoodMetamorphableByAdding
   - type: SolutionContainerManager
     solutions:
       food:
         maxVol: 4 # 1/2 bun
+        canReact: false
         reagents:
         - ReagentId: Nutriment
           Quantity: 2.6
@@ -179,6 +192,9 @@
           Quantity: 2.6
         - ReagentId: Protein
           Quantity: 0.25
+  - type: FoodSequenceElement
+    entries:
+      Burger: CP14BunTopBurger
   - type: CP14TemperatureTransformation
     entries:
     - temperatureRange: 400, 500

--- a/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/meat.yml
@@ -184,6 +184,9 @@
           Quantity: 4
         - ReagentId: Egg
           Quantity: 6
+  - type: FoodSequenceElement
+    entries:
+      Burger: CP14CutletBurger
   - type: CP14TemperatureTransformation
     entries:
     - temperatureRange: 400, 500
@@ -210,6 +213,9 @@
           Quantity: 4
         - ReagentId: EggCooked
           Quantity: 6
+  - type: FoodSequenceElement
+    entries:
+      Burger: CP14CutletCookedBurger
   - type: CP14TemperatureTransformation
     entries:
     - temperatureRange: 400, 500

--- a/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/meat.yml
@@ -186,7 +186,7 @@
           Quantity: 6
   - type: FoodSequenceElement
     entries:
-      Burger: CP14CutletBurger
+      Sandwich: CP14CutletSandwich
   - type: CP14TemperatureTransformation
     entries:
     - temperatureRange: 400, 500
@@ -215,7 +215,7 @@
           Quantity: 6
   - type: FoodSequenceElement
     entries:
-      Burger: CP14CutletCookedBurger
+      Sandwich: CP14CutletCookedSandwich
   - type: CP14TemperatureTransformation
     entries:
     - temperatureRange: 400, 500

--- a/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/meat.yml
@@ -186,7 +186,7 @@
           Quantity: 6
   - type: FoodSequenceElement
     entries:
-      Sandwich: CP14CutletSandwich
+      CP14Sandwich: CP14CutletSandwich
   - type: CP14TemperatureTransformation
     entries:
     - temperatureRange: 400, 500
@@ -215,7 +215,7 @@
           Quantity: 6
   - type: FoodSequenceElement
     entries:
-      Sandwich: CP14CutletCookedSandwich
+      CP14Sandwich: CP14CutletCookedSandwich
   - type: CP14TemperatureTransformation
     entries:
     - temperatureRange: 400, 500

--- a/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/produce.yml
@@ -71,6 +71,9 @@
           Quantity: 2.5
         - ReagentId: Vitamin
           Quantity: 0.25
+  - type: FoodSequenceElement
+    entries:
+      Burger: CP14CabbageBurger
 
 - type: entity
   id: CP14FoodPumpkin
@@ -146,6 +149,9 @@
           Quantity: 4
         - ReagentId: Vitamin
           Quantity: 1
+  - type: FoodSequenceElement
+    entries:
+      Burger: CP14PumpkinBurger
 
 - type: entity
   id: CP14FoodPotato
@@ -225,6 +231,9 @@
   - type: Tag
     tags:
     - CP14FarmFood
+  - type: FoodSequenceElement
+    entries:
+      Burger: CP14CucumberBurger
 
 - type: entity
   id: CP14FoodTomatoes
@@ -324,6 +333,9 @@
           Quantity: 1
         - ReagentId: Vitamin
           Quantity: 1
+  - type: FoodSequenceElement
+    entries:
+      Burger: CP14TomatoesBurger
 
 - type: entity
   id: CP14FoodApple
@@ -388,6 +400,9 @@
           Quantity: 2.5
         - ReagentId: Vitamin
           Quantity: 1
+  - type: FoodSequenceElement
+    entries:
+      Burger: CP14AppleBurger
 
 - type: entity
   id: CP14FoodPepper

--- a/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/produce.yml
@@ -73,7 +73,7 @@
           Quantity: 0.25
   - type: FoodSequenceElement
     entries:
-      Burger: CP14CabbageBurger
+      Sandwich: CP14CabbageSandwich
 
 - type: entity
   id: CP14FoodPumpkin
@@ -151,7 +151,7 @@
           Quantity: 1
   - type: FoodSequenceElement
     entries:
-      Burger: CP14PumpkinBurger
+      Sandwich: CP14PumpkinSandwich
 
 - type: entity
   id: CP14FoodPotato
@@ -233,7 +233,7 @@
     - CP14FarmFood
   - type: FoodSequenceElement
     entries:
-      Burger: CP14CucumberBurger
+      Sandwich: CP14CucumberSandwich
 
 - type: entity
   id: CP14FoodTomatoes
@@ -335,7 +335,7 @@
           Quantity: 1
   - type: FoodSequenceElement
     entries:
-      Burger: CP14TomatoesBurger
+      Sandwich: CP14TomatoesSandwich
 
 - type: entity
   id: CP14FoodApple
@@ -402,7 +402,7 @@
           Quantity: 1
   - type: FoodSequenceElement
     entries:
-      Burger: CP14AppleBurger
+      Sandwich: CP14AppleSandwich
 
 - type: entity
   id: CP14FoodPepper

--- a/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/produce.yml
@@ -73,7 +73,7 @@
           Quantity: 0.25
   - type: FoodSequenceElement
     entries:
-      Sandwich: CP14CabbageSandwich
+      CP14Sandwich: CP14CabbageSandwich
 
 - type: entity
   id: CP14FoodPumpkin
@@ -151,7 +151,7 @@
           Quantity: 1
   - type: FoodSequenceElement
     entries:
-      Sandwich: CP14PumpkinSandwich
+      CP14Sandwich: CP14PumpkinSandwich
 
 - type: entity
   id: CP14FoodPotato
@@ -233,7 +233,7 @@
     - CP14FarmFood
   - type: FoodSequenceElement
     entries:
-      Sandwich: CP14CucumberSandwich
+      CP14Sandwich: CP14CucumberSandwich
 
 - type: entity
   id: CP14FoodTomatoes
@@ -335,7 +335,7 @@
           Quantity: 1
   - type: FoodSequenceElement
     entries:
-      Sandwich: CP14TomatoesSandwich
+      CP14Sandwich: CP14TomatoesSandwich
 
 - type: entity
   id: CP14FoodApple
@@ -402,7 +402,7 @@
           Quantity: 1
   - type: FoodSequenceElement
     entries:
-      Sandwich: CP14AppleSandwich
+      CP14Sandwich: CP14AppleSandwich
 
 - type: entity
   id: CP14FoodPepper

--- a/Resources/Prototypes/_CP14/Recipes/Cooking/food_sequence_element.yml
+++ b/Resources/Prototypes/_CP14/Recipes/Cooking/food_sequence_element.yml
@@ -1,0 +1,98 @@
+# Bun bottom
+
+- type: foodSequenceElement
+  id: CP14BunTopBurger
+  final: true
+  sprites:
+  - sprite: _CP14/Objects/Consumable/Food/dough.rsi
+    state: bun_cooked_slice_top
+  tags:
+  - Bun
+
+# Meat
+
+- type: foodSequenceElement
+  id: CP14CutletBurger
+  sprites:
+  - sprite: _CP14/Objects/Consumable/Food/meat.rsi
+    state: cutlet
+  tags:
+  - Cutlet
+  - CP14Meat
+
+- type: foodSequenceElement
+  id: CP14CutletCookedBurger
+  sprites:
+  - sprite: _CP14/Objects/Consumable/Food/meat.rsi
+    state: cutlet_cooked
+  tags:
+  - Cooked
+  - Cutlet
+  - CP14Meat
+
+# Cheese
+
+- type: foodSequenceElement
+  id: CP14CheeseBurger
+  name: food-sequence-content-cheese
+  sprites:
+  - sprite: _CP14/Objects/Consumable/Food/cheese.rsi
+    state: cheese_slice
+  tags:
+  - Cheese
+
+# Cabbage
+
+- type: foodSequenceElement
+  id: CP14CabbageBurger
+  name: food-sequence-content-cabbage
+  sprites:
+  - sprite: _CP14/Objects/Flora/Farm/cabbage.rsi
+    state: slice1
+  tags:
+  - Vegetable
+
+# Pumpkin
+
+- type: foodSequenceElement
+  id: CP14PumpkinBurger
+  name: cp14-food-sequence-content-pumpkin
+  sprites:
+  - sprite: _CP14/Objects/Flora/Farm/pumpkin.rsi
+    state: slice1
+  tags:
+  - Vegetable
+
+# Cucumber
+
+- type: foodSequenceElement
+  id: CP14CucumberBurger
+  name: cp14-food-sequence-content-cucumber
+  sprites:
+  - sprite: _CP14/Objects/Flora/Farm/cucumber.rsi
+    state: base1
+  tags:
+  - Vegetable
+
+# Tomatoes
+
+- type: foodSequenceElement
+  id: CP14TomatoesBurger
+  name: food-sequence-content-tomato
+  sprites:
+  - sprite: _CP14/Objects/Flora/Farm/tomatoes.rsi
+    state: slice1
+  tags:
+  - Fruit
+  - Vegetable
+
+# Apple
+
+- type: foodSequenceElement
+  id: CP14AppleBurger
+  name: food-sequence-content-apple
+  sprites:
+  - sprite: _CP14/Objects/Flora/Farm/apple.rsi
+    state: slice1
+  tags:
+  - Fruit

--- a/Resources/Prototypes/_CP14/Recipes/Cooking/food_sequence_element.yml
+++ b/Resources/Prototypes/_CP14/Recipes/Cooking/food_sequence_element.yml
@@ -1,7 +1,7 @@
 # Bun bottom
 
 - type: foodSequenceElement
-  id: CP14BunTopBurger
+  id: CP14BunTopSandwich
   final: true
   sprites:
   - sprite: _CP14/Objects/Consumable/Food/dough.rsi
@@ -12,7 +12,7 @@
 # Meat
 
 - type: foodSequenceElement
-  id: CP14CutletBurger
+  id: CP14CutletSandwich
   sprites:
   - sprite: _CP14/Objects/Consumable/Food/meat.rsi
     state: cutlet
@@ -21,7 +21,7 @@
   - CP14Meat
 
 - type: foodSequenceElement
-  id: CP14CutletCookedBurger
+  id: CP14CutletCookedSandwich
   sprites:
   - sprite: _CP14/Objects/Consumable/Food/meat.rsi
     state: cutlet_cooked
@@ -33,7 +33,7 @@
 # Cheese
 
 - type: foodSequenceElement
-  id: CP14CheeseBurger
+  id: CP14CheeseSandwich
   name: food-sequence-content-cheese
   sprites:
   - sprite: _CP14/Objects/Consumable/Food/cheese.rsi
@@ -44,7 +44,7 @@
 # Cabbage
 
 - type: foodSequenceElement
-  id: CP14CabbageBurger
+  id: CP14CabbageSandwich
   name: food-sequence-content-cabbage
   sprites:
   - sprite: _CP14/Objects/Flora/Farm/cabbage.rsi
@@ -55,7 +55,7 @@
 # Pumpkin
 
 - type: foodSequenceElement
-  id: CP14PumpkinBurger
+  id: CP14PumpkinSandwich
   name: cp14-food-sequence-content-pumpkin
   sprites:
   - sprite: _CP14/Objects/Flora/Farm/pumpkin.rsi
@@ -66,7 +66,7 @@
 # Cucumber
 
 - type: foodSequenceElement
-  id: CP14CucumberBurger
+  id: CP14CucumberSandwich
   name: cp14-food-sequence-content-cucumber
   sprites:
   - sprite: _CP14/Objects/Flora/Farm/cucumber.rsi
@@ -77,7 +77,7 @@
 # Tomatoes
 
 - type: foodSequenceElement
-  id: CP14TomatoesBurger
+  id: CP14TomatoesSandwich
   name: food-sequence-content-tomato
   sprites:
   - sprite: _CP14/Objects/Flora/Farm/tomatoes.rsi
@@ -89,7 +89,7 @@
 # Apple
 
 - type: foodSequenceElement
-  id: CP14AppleBurger
+  id: CP14AppleSandwich
   name: food-sequence-content-apple
   sprites:
   - sprite: _CP14/Objects/Flora/Farm/apple.rsi

--- a/Resources/Prototypes/_CP14/tags.yml
+++ b/Resources/Prototypes/_CP14/tags.yml
@@ -144,3 +144,6 @@
 
 - type: Tag
   id: CP14EnergyCrystal
+
+- type: Tag
+  id: Sandwich

--- a/Resources/Prototypes/_CP14/tags.yml
+++ b/Resources/Prototypes/_CP14/tags.yml
@@ -146,4 +146,4 @@
   id: CP14EnergyCrystal
 
 - type: Tag
-  id: Sandwich
+  id: CP14Sandwich


### PR DESCRIPTION
## About the PR

The buns can now be used to make sandwichs with different toppings.
Теперь из булок можно делать бутерброды с разной начинкой.

## Why / Balance

More content for tavernkeepers.
Больше контента для тавернщиков.

## Media

![image](https://github.com/user-attachments/assets/f7a2a011-ecee-4608-8c02-9e69f3a37a46)
