### PR TITLE
Changed smoking pipe to not warn when igniting

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Smokeables/Pipes/pipe.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Smokeables/Pipes/pipe.yml
@@ -18,6 +18,8 @@
   - type: Appearance
   - type: BurnStateVisuals
     unlitIcon: unlit-icon
+  - type: CP14IgnitionModifier
+    hideCaution: true
 
 - type: entity
   id: CP14SmokingPipeFilledTobacco


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
<!-- Что вы изменили в своем пулл реквесте? -->
added hideCaution to BaseSmokingPipe
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
<!-- Зачем нужно это изменение? Прикрепите любые обсуждения или проблемы здесь. Опишите, как это повлияет на текущий баланс игры. -->
Smoking pipe is intended to be lit, but currently gives red warning text when attempting to ignite. Similar ignitable items like torches already have this behavior.
## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->
<!--
Пулл реквесты, которые несут за собой игровые изменения (добавления одежды, предметов и так далее) требуют чтобы вы прикрепили скриншоты или видеоролики, демонстрирующие эти изменения.
Небольшие исправления не считаются.
-->
