### PR TITLE
Critical bugfixes

### DIFF
--- a/Content.Server/_CP14/DemiplaneTraveling/CP14StationDemiplaneMapSystem.cs
+++ b/Content.Server/_CP14/DemiplaneTraveling/CP14StationDemiplaneMapSystem.cs
@@ -236,7 +236,7 @@ public sealed partial class CP14StationDemiplaneMapSystem : CP14SharedStationDem
                 new Vector2(specialPos.X, specialPos.Y),
                 false,
                 locationConfig: special.Location,
-                modifiers: special.Modifiers
+                modifiers: [..special.Modifiers]
             );
             grid[specialPos] = specialNode;
             specialPositions.Add(specialPos);

--- a/Content.Shared/_CP14/Demiplane/Prototypes/CP14SpecialDemiplanePrototype.cs
+++ b/Content.Shared/_CP14/Demiplane/Prototypes/CP14SpecialDemiplanePrototype.cs
@@ -29,5 +29,5 @@ public sealed partial class CP14SpecialDemiplanePrototype : IPrototype
     /// Modifiers that will be automatically added to the demiplane when it is generated.
     /// </summary>
     [DataField]
-    public List<ProtoId<CP14DemiplaneModifierPrototype>>? Modifiers = new();
+    public List<ProtoId<CP14DemiplaneModifierPrototype>> Modifiers = new();
 }

--- a/Content.Shared/_CP14/Workbench/Requirements/MaterialResource.cs
+++ b/Content.Shared/_CP14/Workbench/Requirements/MaterialResource.cs
@@ -75,12 +75,14 @@ public sealed partial class MaterialResource : CP14WorkbenchCraftRequirement
                 if (mat.Key != Material)
                     continue;
 
+                if (requiredCount <= 0)
+                    return;
+
                 if (stack is null)
                 {
                     var value = (int)MathF.Min(requiredCount, mat.Value);
                     requiredCount -= value;
                     entManager.DeleteEntity(placedEntity);
-                    continue;
                 }
                 else
                 {

--- a/Resources/Prototypes/_CP14/Procedural/Demiplane/Locations/cave_ice.yml
+++ b/Resources/Prototypes/_CP14/Procedural/Demiplane/Locations/cave_ice.yml
@@ -1,7 +1,7 @@
 - type: cp14DemiplaneLocation
   id: T1IceCaves
   levels:
-    min: 3
+    min: 2
     max: 7
   icon:
     sprite: _CP14/Interface/Misc/demiplane_locations.rsi

--- a/Resources/Prototypes/_CP14/Procedural/Demiplane/Locations/cave_magma.yml
+++ b/Resources/Prototypes/_CP14/Procedural/Demiplane/Locations/cave_magma.yml
@@ -1,7 +1,7 @@
 - type: cp14DemiplaneLocation
   id: T1MagmaCaves
   levels:
-    min: 7
+    min: 4
     max: 10
   icon:
     sprite: _CP14/Interface/Misc/demiplane_locations.rsi

--- a/Resources/Prototypes/_CP14/Procedural/Demiplane/Modifiers/Reward/rooms.yml
+++ b/Resources/Prototypes/_CP14/Procedural/Demiplane/Modifiers/Reward/rooms.yml
@@ -1,7 +1,7 @@
 - type: cp14DemiplaneModifier
   id: ArtifactRoom
   levels:
-    min: 1
+    min: 3
     max: 10
   generationWeight: 2
   categories:


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
<!-- Что вы изменили в своем пулл реквесте? -->
- Исправлен баг с излишним удалением скрапа при переплавке в слитки
- Исправлен баг с дубликацией модификаторов на карте демипланов

---

- Fixed a bug with excessive removal of scrap when melting into ingots
- Fixed a bug with duplicate modifiers on the demiplane map