### PR TITLE
Remove Guildmaster & Merchant roles

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Structures/Doors/Locked/guildmaster.yml
+++ b/Resources/Prototypes/_CP14/Entities/Structures/Doors/Locked/guildmaster.yml
@@ -28,4 +28,4 @@
   - type: CP14Lock
     autoGenerateShape: DemiplaneCrystal
   - type: Lock
-    locked: true
+    locked: false

--- a/Resources/Prototypes/_CP14/Entities/Structures/Specific/Demiplanes/round_end.yml
+++ b/Resources/Prototypes/_CP14/Entities/Structures/Specific/Demiplanes/round_end.yml
@@ -180,9 +180,9 @@
           acts: ["Destruction"]
         - !type:SpawnEntitiesBehavior
           spawn:
-            CP14DimensitCrystal:
-              min: 4
-              max: 6
+            #CP14DimensitCrystal:
+            #  min: 4
+            #  max: 6
         - !type:SpawnEntitiesBehavior
           spawn:
             CP14SkyLightningPurple:

--- a/Resources/Prototypes/_CP14/Entities/Structures/Specific/Demiplanes/round_end.yml
+++ b/Resources/Prototypes/_CP14/Entities/Structures/Specific/Demiplanes/round_end.yml
@@ -178,11 +178,11 @@
             collection: GlassBreak
         - !type:DoActsBehavior
           acts: ["Destruction"]
-        - !type:SpawnEntitiesBehavior
-          spawn:
-            #CP14DimensitCrystal:
-            #  min: 4
-            #  max: 6
+        #- !type:SpawnEntitiesBehavior
+        #  spawn:
+        #    CP14DimensitCrystal:
+        #      min: 4
+        #      max: 6
         - !type:SpawnEntitiesBehavior
           spawn:
             CP14SkyLightningPurple:

--- a/Resources/Prototypes/_CP14/Maps/Frigid_Coast.yml
+++ b/Resources/Prototypes/_CP14/Maps/Frigid_Coast.yml
@@ -14,14 +14,14 @@
         - type: StationJobs
           availableJobs:
             #Mercenary
-            CP14Guildmaster: [1, 1]
+            #CP14Guildmaster: [1, 1]
             CP14Adventurer: [ -1, -1 ]
             #Artisans
             CP14Apprentice: [ 3, 3 ]
             CP14Alchemist: [ 2, 2 ]
             CP14Blacksmith: [ 2, 2 ]
             CP14Innkeeper: [ 2, 3 ]
-            CP14Merchant: [2, 2]
+            #CP14Merchant: [2, 2]
             #Guard
             CP14Guard: [5, 5]
             CP14GuardCommander: [1, 1]

--- a/Resources/Prototypes/_CP14/Maps/comoss.yml
+++ b/Resources/Prototypes/_CP14/Maps/comoss.yml
@@ -14,14 +14,14 @@
         - type: StationJobs
           availableJobs:
             #Mercenary
-            CP14Guildmaster: [1, 1]
+            #CP14Guildmaster: [1, 1]
             CP14Adventurer: [ -1, -1 ]
             #Artisans
             CP14Apprentice: [ 5, 5 ]
             CP14Alchemist: [ 2, 2 ]
             CP14Blacksmith: [ 2, 2 ]
             CP14Innkeeper: [ 3, 4 ]
-            CP14Merchant: [2, 2]
+            #CP14Merchant: [2, 2]
             #Guard
             CP14Guard: [8, 8]
             CP14GuardCommander: [1, 1]

--- a/Resources/Prototypes/_CP14/Roles/Jobs/Artisan/alchemist.yml
+++ b/Resources/Prototypes/_CP14/Roles/Jobs/Artisan/alchemist.yml
@@ -11,9 +11,9 @@
       skills:
       - AlchemyVision
   requirements:
-    - !type:RoleTimeRequirement
-      role: CP14JobApprentice
-      time: 3600 # 1 hours
+    #- !type:RoleTimeRequirement
+    #  role: CP14JobApprentice
+    #  time: 3600 # 1 hours
     - !type:TraitsRequirement
       inverted: true
       traits:

--- a/Resources/Prototypes/_CP14/Roles/Jobs/Artisan/blacksmith.yml
+++ b/Resources/Prototypes/_CP14/Roles/Jobs/Artisan/blacksmith.yml
@@ -14,10 +14,10 @@
       - GoldMelting
       - GlassMelting
       - MithrilMelting
-  requirements:
-    - !type:RoleTimeRequirement
-      role: CP14JobApprentice
-      time: 3600 # 1 hour
+  #requirements:
+    #- !type:RoleTimeRequirement
+    #  role: CP14JobApprentice
+    #  time: 3600 # 1 hour
 
 - type: startingGear
   id: CP14BlacksmithGear

--- a/Resources/Prototypes/_CP14/Roles/Jobs/Mercenary/guildmaster.yml
+++ b/Resources/Prototypes/_CP14/Roles/Jobs/Mercenary/guildmaster.yml
@@ -1,5 +1,6 @@
 - type: job
   id: CP14Guildmaster
+  setPreference: false
   name: cp14-job-name-guildmaster
   description: cp14-job-desc-guildmaster
   playTimeTracker: CP14JobGuildmaster

--- a/Resources/Prototypes/_CP14/Roles/Jobs/Traders/merchant.yml
+++ b/Resources/Prototypes/_CP14/Roles/Jobs/Traders/merchant.yml
@@ -1,5 +1,6 @@
 - type: job
   id: CP14Merchant
+  setPreference: false
   name: cp14-job-name-merchant
   description: cp14-job-desc-merchant
   playTimeTracker: CP14JobMerchant


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
<!-- Что вы изменили в своем пулл реквесте? -->
Эти 2 роли на текущий момент полностью сломаны и не играбельны. Для незнающих новичков это может быть фрустрирующий опыт. Роли убраны для выбора в меню создания персонажа до их переработки в будущем. 

Двери к кристаллу демиплана теперь раундстартом открыты.

Подготовка более-менее комфортной ситуации в билде перед запуском английского ЗБТ

---

These 2 roles are currently completely broken and unplayable. This can be a frustrating experience for unfamiliar newbies. The roles have been removed for selection in the character creation menu until they are redesigned in the future. 

The doors to the demiplane crystal are now open from roundstart.

Preparing a more or less comfortable build situation before launching the English CBT