### PR TITLE
Rotated Keyfile

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Objects/Keys/tools.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Keys/tools.yml
@@ -34,7 +34,7 @@
   categories: [ ForkFiltered ]
   components:
   - type: Item
-    storedRotation: 0
+    storedRotation: 45
   - type: Sprite
     sprite: _CP14/Objects/keys.rsi
     state: file

--- a/Resources/Prototypes/_CP14/Entities/Objects/Keys/tools.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Keys/tools.yml
@@ -34,7 +34,7 @@
   categories: [ ForkFiltered ]
   components:
   - type: Item
-    storedRotation: -45
+    storedRotation: 0
   - type: Sprite
     sprite: _CP14/Objects/keys.rsi
     state: file


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Rotated the inventory Key File by 45 degrees to match the original sprite while in inventory.
<!-- Что вы изменили в своем пулл реквесте? -->

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Intended to solve [Issue 1237](https://github.com/crystallpunk-14/crystall-punk-14/issues/1237)
<!-- Зачем нужно это изменение? Прикрепите любые обсуждения или проблемы здесь. Опишите, как это повлияет на текущий баланс игры. -->

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->
A small change, my first PR.
Before
![before](https://github.com/user-attachments/assets/62258a4d-c764-4243-bf69-2ecc25b404a4)
After
![after_1](https://github.com/user-attachments/assets/40e2e124-4e8d-4487-8b22-dc0d5cfde7f6)
<!--
Пулл реквесты, которые несут за собой игровые изменения (добавления одежды, предметов и так далее) требуют чтобы вы прикрепили скриншоты или видеоролики, демонстрирующие эти изменения.
Небольшие исправления не считаются.
-->
