### PR TITLE
fix crash on core destruction

### DIFF
--- a/Content.Shared/_CP14/Demiplane/Components/CP14DemiplaneTimedDestructionComponent.cs
+++ b/Content.Shared/_CP14/Demiplane/Components/CP14DemiplaneTimedDestructionComponent.cs
@@ -1,11 +1,12 @@
 using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared._CP14.Demiplane.Components;
 
 /// <summary>
 /// Destroy demiplane after time
 /// </summary>
-[RegisterComponent, AutoGenerateComponentState, AutoGenerateComponentPause, Access(typeof(CP14SharedDemiplaneSystem))]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause, Access(typeof(CP14SharedDemiplaneSystem))]
 public sealed partial class CP14DemiplaneTimedDestructionComponent : Component
 {
     [DataField]


### PR DESCRIPTION
## About the PR

Server tries and fails to dirty the component as it wasn't networked.

## Why / Balance

Bugfix

## Media


https://github.com/user-attachments/assets/9de6e0cc-5980-4d72-b0cf-bf6f25a6d804



```
[FATL] unhandled: Robust.Shared.Utility.DebugAssertException: Attempted to dirty a non-networked component: Content.Shared._CP14.Demiplane.Components.CP14DemiplaneTimedDestructionComponent
   at Robust.Shared.Utility.DebugTools.Assert(Boolean condition, AssertInterpolatedStringHandler& message) in /home/ignaz/git/crystall-punk-14/RobustToolbox/Robust.Shared/Utility/DebugTools.cs:line 215
   at Robust.Shared.GameObjects.EntityManager.Dirty(EntityUid uid, IComponent component, MetaDataComponent meta) in /home/ignaz/git/crystall-punk-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 400
   at Content.Server._CP14.Demiplane.CP14DemiplaneSystem.UpdateDestruction(Single frameTime) in /home/ignaz/git/crystall-punk-14/Content.Server/_CP14/Demiplane/CP14DemiplaneSystem.Destruction.cs:line 63
   at Content.Server._CP14.Demiplane.CP14DemiplaneSystem.Update(Single frameTime) in /home/ignaz/git/crystall-punk-14/Content.Server/_CP14/Demiplane/CP14DemiplaneSystem.cs:line 84
   at Robust.Shared.GameObjects.EntitySystemManager.TickUpdate(Single frameTime, Boolean noPredictions) in /home/ignaz/git/crystall-punk-14/RobustToolbox/Robust.Shared/GameObjects/EntitySystemManager.cs:line 318
   at Robust.Shared.GameObjects.EntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/ignaz/git/crystall-punk-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 273
   at Robust.Server.GameObjects.ServerEntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/ignaz/git/crystall-punk-14/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 170
   at Robust.Server.BaseServer.Update(FrameEventArgs frameEventArgs) in /home/ignaz/git/crystall-punk-14/RobustToolbox/Robust.Server/BaseServer.cs:line 731
   at Robust.Server.BaseServer.<SetupMainLoop>b__67_1(Object sender, FrameEventArgs args) in /home/ignaz/git/crystall-punk-14/RobustToolbox/Robust.Server/BaseServer.cs:line 544
   at Robust.Shared.Timing.GameLoop.Run() in /home/ignaz/git/crystall-punk-14/RobustToolbox/Robust.Shared/Timing/GameLoop.cs:line 235
   at Robust.Server.BaseServer.MainLoop() in /home/ignaz/git/crystall-punk-14/RobustToolbox/Robust.Server/BaseServer.cs:line 571
   at Robust.Server.Program.ParsedMain(CommandLineArgs args, Boolean contentStart, ServerOptions options) in /home/ignaz/git/crystall-punk-14/RobustToolbox/Robust.Server/Program.cs:line 74
   at Robust.Server.Program.Start(String[] args, ServerOptions options, Boolean contentStart) in /home/ignaz/git/crystall-punk-14/RobustToolbox/Robust.Server/Program.cs:line 42
   at Robust.Server.ContentStart.Start(String[] args) in /home/ignaz/git/crystall-punk-14/RobustToolbox/Robust.Server/ContentStart.cs:line 10
   at Content.Server.Program.Main(String[] args) in /home/ignaz/git/crystall-punk-14/Content.Server/Program.cs:line 9
Unhandled exception. Robust.Shared.Utility.DebugAssertException: Attempted to dirty a non-networked component: Content.Shared._CP14.Demiplane.Components.CP14DemiplaneTimedDestructionComponent
   at Robust.Shared.Utility.DebugTools.Assert(Boolean condition, AssertInterpolatedStringHandler& message) in /home/ignaz/git/crystall-punk-14/RobustToolbox/Robust.Shared/Utility/DebugTools.cs:line 215
   at Robust.Shared.GameObjects.EntityManager.Dirty(EntityUid uid, IComponent component, MetaDataComponent meta) in /home/ignaz/git/crystall-punk-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 400
   at Content.Server._CP14.Demiplane.CP14DemiplaneSystem.UpdateDestruction(Single frameTime) in /home/ignaz/git/crystall-punk-14/Content.Server/_CP14/Demiplane/CP14DemiplaneSystem.Destruction.cs:line 63
   at Content.Server._CP14.Demiplane.CP14DemiplaneSystem.Update(Single frameTime) in /home/ignaz/git/crystall-punk-14/Content.Server/_CP14/Demiplane/CP14DemiplaneSystem.cs:line 84
   at Robust.Shared.GameObjects.EntitySystemManager.TickUpdate(Single frameTime, Boolean noPredictions) in /home/ignaz/git/crystall-punk-14/RobustToolbox/Robust.Shared/GameObjects/EntitySystemManager.cs:line 318
   at Robust.Shared.GameObjects.EntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/ignaz/git/crystall-punk-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 273
   at Robust.Server.GameObjects.ServerEntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/ignaz/git/crystall-punk-14/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 170
   at Robust.Server.BaseServer.Update(FrameEventArgs frameEventArgs) in /home/ignaz/git/crystall-punk-14/RobustToolbox/Robust.Server/BaseServer.cs:line 731
   at Robust.Server.BaseServer.<SetupMainLoop>b__67_1(Object sender, FrameEventArgs args) in /home/ignaz/git/crystall-punk-14/RobustToolbox/Robust.Server/BaseServer.cs:line 544
   at Robust.Shared.Timing.GameLoop.Run() in /home/ignaz/git/crystall-punk-14/RobustToolbox/Robust.Shared/Timing/GameLoop.cs:line 235
   at Robust.Server.BaseServer.MainLoop() in /home/ignaz/git/crystall-punk-14/RobustToolbox/Robust.Server/BaseServer.cs:line 571
   at Robust.Server.Program.ParsedMain(CommandLineArgs args, Boolean contentStart, ServerOptions options) in /home/ignaz/git/crystall-punk-14/RobustToolbox/Robust.Server/Program.cs:line 74
   at Robust.Server.Program.Start(String[] args, ServerOptions options, Boolean contentStart) in /home/ignaz/git/crystall-punk-14/RobustToolbox/Robust.Server/Program.cs:line 42
   at Robust.Server.ContentStart.Start(String[] args) in /home/ignaz/git/crystall-punk-14/RobustToolbox/Robust.Server/ContentStart.cs:line 10
   at Content.Server.Program.Main(String[] args) in /home/ignaz/git/crystall-punk-14/Content.Server/Program.cs:line 9
```