### PR TITLE
make heat and freeze work on reagents

### DIFF
--- a/Content.Server/_CP14/EntityEffects/Effects/AdjustAllSolutionThermalEnergy.cs
+++ b/Content.Server/_CP14/EntityEffects/Effects/AdjustAllSolutionThermalEnergy.cs
@@ -43,11 +43,13 @@ public sealed partial class AdjustAllSolutionThermalEnergy : EntityEffect
             var heatCap = solution.Comp.Solution.GetHeatCapacity(null);
             var deltaT = _delta / heatCap;
 
-            solution.Comp.Solution.Temperature = Math.Clamp(solution.Comp.Solution.Temperature + deltaT, _minTemp, _maxTemp);
+            var temperature = Math.Clamp(solution.Comp.Solution.Temperature + deltaT, _minTemp, _maxTemp);
+            solutionContainer.SetTemperature(solution, temperature);
         }
     }
 
     protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
-    => Loc.GetString("reagent-effect-guidebook-adjust-solution-temperature-effect",
-        ("chance", Probability), ("deltasign", MathF.Sign(_delta)), ("mintemp", _minTemp), ("maxtemp", _maxTemp));
+    {
+        return null;
+    }
 }

--- a/Content.Server/_CP14/EntityEffects/Effects/AdjustAllSolutionThermalEnergy.cs
+++ b/Content.Server/_CP14/EntityEffects/Effects/AdjustAllSolutionThermalEnergy.cs
@@ -1,0 +1,53 @@
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.EntityEffects;
+using JetBrains.Annotations;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.EntityEffects.Effects;
+
+/// <summary>
+///     Adjusts the thermal energy of all the solutions inside the container.
+/// </summary>
+[UsedImplicitly]
+[DataDefinition]
+public sealed partial class AdjustAllSolutionThermalEnergy : EntityEffect
+{
+    /// <summary>
+    ///     The change in energy.
+    /// </summary>
+    [DataField("delta", required: true)] private float _delta;
+
+    /// <summary>
+    ///     The minimum temperature this effect can reach.
+    /// </summary>
+    [DataField("minTemp")] private float _minTemp = 0.0f;
+
+    /// <summary>
+    ///     The maximum temperature this effect can reach.
+    /// </summary>
+    [DataField("maxTemp")] private float _maxTemp = float.PositiveInfinity;
+
+    public override void Effect(EntityEffectBaseArgs args)
+    {
+        var solutionContainer = args.EntityManager.System<SharedSolutionContainerSystem>();
+        foreach (var (_, solution) in solutionContainer.EnumerateSolutions(args.TargetEntity))
+        {
+            if (solution.Comp.Solution.Volume == 0)
+                continue;
+
+            if (_delta > 0 && solution.Comp.Solution.Temperature >= _maxTemp)
+                return;
+            if (_delta < 0 && solution.Comp.Solution.Temperature <= _minTemp)
+                return;
+
+            var heatCap = solution.Comp.Solution.GetHeatCapacity(null);
+            var deltaT = _delta / heatCap;
+
+            solution.Comp.Solution.Temperature = Math.Clamp(solution.Comp.Solution.Temperature + deltaT, _minTemp, _maxTemp);
+        }
+    }
+
+    protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+    => Loc.GetString("reagent-effect-guidebook-adjust-solution-temperature-effect",
+        ("chance", Probability), ("deltasign", MathF.Sign(_delta)), ("mintemp", _minTemp), ("maxtemp", _maxTemp));
+}

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/heat.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/heat.yml
@@ -18,11 +18,11 @@
       - CP14ImpactEffectHeat
     - !type:CP14SpellApplyEntityEffect
       effects:
+      - !type:AdjustAllSolutionThermalEnergy
+        delta: 3600 # One full use heats 100u from ~300k to ~650k
       - !type:AdjustTemperature
         amount: 36000
       - !type:ExtinguishReaction
-      - !type:AdjustAllSolutionThermalEnergy
-        delta: 3600 # One full use heats 100u from ~300k to ~650k
   - type: CP14MagicEffectVerbalAspect
     startSpeech: "Vos adepto calidum..."
   - type: CP14MagicEffectCastingVisual

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/heat.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/heat.yml
@@ -21,6 +21,8 @@
       - !type:AdjustTemperature
         amount: 36000
       - !type:ExtinguishReaction
+      - !type:AdjustAllSolutionThermalEnergy
+        delta: 3600 # One full use heats 100u from ~300k to ~650k
   - type: CP14MagicEffectVerbalAspect
     startSpeech: "Vos adepto calidum..."
   - type: CP14MagicEffectCastingVisual

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/freeze.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/freeze.yml
@@ -25,6 +25,8 @@
       - !type:AdjustTemperature
         amount: -12000
       - !type:ExtinguishReaction
+      - !type:AdjustAllSolutionThermalEnergy
+        delta: -1200 # One full use cools 100u from ~300k to ~250k
   - type: CP14MagicEffectVerbalAspect
     startSpeech: "Vos adepto frigus..."
   - type: CP14MagicEffectCastingVisual

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/freeze.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/freeze.yml
@@ -22,11 +22,11 @@
         walkSpeedModifier: 0.5
         sprintSpeedModifier: 0.5
         statusLifetime: 2
+      - !type:AdjustAllSolutionThermalEnergy
+        delta: -1200 # One full use cools 100u from ~300k to ~250k
       - !type:AdjustTemperature
         amount: -12000
       - !type:ExtinguishReaction
-      - !type:AdjustAllSolutionThermalEnergy
-        delta: -1200 # One full use cools 100u from ~300k to ~250k
   - type: CP14MagicEffectVerbalAspect
     startSpeech: "Vos adepto frigus..."
   - type: CP14MagicEffectCastingVisual


### PR DESCRIPTION
## About the PR

This PR adds more world interactions to the heat and freeze spell by making them also adjust the temperature of reagents inside the target.

## Why / Balance

It's immersive and gives town jobs more interactions with either the magic system or other players that have those skills.

## Media


https://github.com/user-attachments/assets/a20aa632-6b2c-4279-b2d5-6faf2da48c6b


https://github.com/user-attachments/assets/dc2a0464-0de3-44e7-8d48-634569f69d1f

