### PR TITLE
Slight Healing magic rebalance

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/cure_heat.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/cure_heat.yml
@@ -9,7 +9,7 @@
   - type: CP14MagicEffectCastSlowdown
     speedMultiplier: 0.5
   - type: CP14MagicEffectManaCost
-    manaCost: 15
+    manaCost: 12
   - type: CP14MagicEffect
     magicType: Life
     telegraphyEffects:

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/cure_heat.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/cure_heat.yml
@@ -9,7 +9,7 @@
   - type: CP14MagicEffectCastSlowdown
     speedMultiplier: 0.5
   - type: CP14MagicEffectManaCost
-    manaCost: 10
+    manaCost: 15
   - type: CP14MagicEffect
     magicType: Life
     telegraphyEffects:

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/cure_poison.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/cure_poison.yml
@@ -9,7 +9,7 @@
   - type: CP14MagicEffectCastSlowdown
     speedMultiplier: 0.5
   - type: CP14MagicEffectManaCost
-    manaCost: 10
+    manaCost: 15
   - type: CP14MagicEffect
     magicType: Life
     telegraphyEffects:

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/cure_poison.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/cure_poison.yml
@@ -29,9 +29,8 @@
             Bloodloss: -10
             Caustic: -10
       - !type:Jitter
-      - !type:ModifyBleedAmount
       - !type:ModifyBloodLevel
-        amount: 15
+        amount: 25
   - type: CP14MagicEffectVerbalAspect
     startSpeech: "Nella coda..."
     endSpeech: "sta il veleno"

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/cure_poison.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/cure_poison.yml
@@ -9,7 +9,7 @@
   - type: CP14MagicEffectCastSlowdown
     speedMultiplier: 0.5
   - type: CP14MagicEffectManaCost
-    manaCost: 15
+    manaCost: 12
   - type: CP14MagicEffect
     magicType: Life
     telegraphyEffects:
@@ -31,7 +31,7 @@
       - !type:Jitter
       - !type:ModifyBleedAmount
       - !type:ModifyBloodLevel
-        amount: 10
+        amount: 15
   - type: CP14MagicEffectVerbalAspect
     startSpeech: "Nella coda..."
     endSpeech: "sta il veleno"

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/cure_wounds.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/cure_wounds.yml
@@ -9,7 +9,7 @@
   - type: CP14MagicEffectCastSlowdown
     speedMultiplier: 0.5
   - type: CP14MagicEffectManaCost
-    manaCost: 15
+    manaCost: 12
   - type: CP14MagicEffect
     magicType: Life
     telegraphyEffects:

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/cure_wounds.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/cure_wounds.yml
@@ -9,7 +9,7 @@
   - type: CP14MagicEffectCastSlowdown
     speedMultiplier: 0.5
   - type: CP14MagicEffectManaCost
-    manaCost: 10
+    manaCost: 15
   - type: CP14MagicEffect
     magicType: Life
     telegraphyEffects:

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/cure_wounds.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/cure_wounds.yml
@@ -29,6 +29,8 @@
             Blunt: -10
             Piercing: -10
       - !type:Jitter
+      - !type:ModifyBleedAmount
+        amount: 5
   - type: CP14MagicEffectVerbalAspect
     startSpeech: "Et curabuntur..."
     endSpeech: "vulnera tua"


### PR DESCRIPTION
### About this PR

This PR bring some modification to mana cost and healing functions on the basic healing spells (cure wounds/burns/poison).

Mana cost increased from 10 to 12 on all three spells(allowing 2 cast for goblins without burning them to a crisp)
Cure Wounds now staunch some bleeding(from 0 to 5 stacks healed, maximum bleeding stacks are at 15 for reference)
Cure Poison(also known as blood purification) no longer stop bleeding(from 15 to 0) BUT restore more blood(from 15 to 25)

### Why/Balance
This PR aim to rebalance resource cost of spells with the aim of pushing player to use potions slightly more.(i do not know how to change spell tier availability, nor found healing_staff yalm(i would have increase healing cost from +50% to +100% considering only alchemist own one and are supposed to craft and use potions, not magic to treat people, i know there can be **ONE** healing staff spawning in a random demiplane but the staff change wouldn't be causing much difference for adventurers)