### PR TITLE
Ice shard nerf

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/ice_shards.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/ice_shards.yml
@@ -66,7 +66,7 @@
     damage:
       types:
         Cold: 4
-        Piercing: 6
+        Piercing: 2
   - type: Sprite
     sprite: _CP14/Effects/Magic/ice_shard.rsi
     layers:


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
<!-- Что вы изменили в своем пулл реквесте? -->
Changes ice shard's piercing damage from 6 to 2.


## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
<!-- Зачем нужно это изменение? Прикрепите любые обсуждения или проблемы здесь. Опишите, как это повлияет на текущий баланс игры. -->
Ice shard has consistently been the best spell main reason for this i think is the bleed stacks it can inflict with the piercing damage, this also nerfs the DPS down to around 10.5 instead of 18.33.
