### PR TITLE
Polymorph return

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/sheep_polymorph.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/sheep_polymorph.yml
@@ -29,6 +29,7 @@
     endSpeech: "pecora tua"
   - type: CP14MagicEffectCastingVisual
     proto: CP14RuneSheepPolymorph
+  - type: CP14MagicEffectAliveTargetRequired
   - type: EntityTargetAction
     whitelist:
       components:

--- a/Resources/Prototypes/_CP14/Skill/healing.yml
+++ b/Resources/Prototypes/_CP14/Skill/healing.yml
@@ -39,6 +39,20 @@
     prerequisite: HealingT1
 
 - type: cp14Skill
+  id: CP14ActionSpellSheepPolymorph
+  skillUiPosition: 0, 4
+  tree: Healing
+  icon:
+    sprite: _CP14/Actions/Spells/misc.rsi
+    state: polymorph
+  effects: 
+  - !type:AddAction
+    action: CP14ActionSpellSheepPolymorph
+  restrictions:
+  - !type:NeedPrerequisite
+    prerequisite: HealingT1
+
+- type: cp14Skill
   id: CP14ActionSpellSpeedBallade
   skillUiPosition: 0, 6
   tree: Healing


### PR DESCRIPTION
## About the PR

Returning the sheep polymorph to the spellcasting branch of healing skins. Also now you can't polymorph corpses.
Возвращение овце-полиморфа в ветку заклинания скилов лечения. Так же теперь нельзя полиморфировать трупов.

## Why / Balance

It's fun with this spell.
С этим заклинанием весело.
