### PR TITLE
Add heal/damage to bloodhealing/absorption 

### DIFF
--- a/Resources/Prototypes/_CP14/Reagents/target_effects.yml
+++ b/Resources/Prototypes/_CP14/Reagents/target_effects.yml
@@ -259,6 +259,10 @@
       effects:
       - !type:ModifyBloodLevel
         amount: 20
+      - !type:HealthChange
+        damage:
+          types:
+            Bloodloss: -10
   pricePerUnit: 2
 
 - type: reagent
@@ -276,6 +280,10 @@
       effects:
       - !type:ModifyBloodLevel
         amount: -10
+      - !type:HealthChange
+        damage:
+          types:
+            Bloodloss: 3
   pricePerUnit: 2
 
 - type: reagent


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
<!-- Что вы изменили в своем пулл реквесте? -->
Made blood healing solution heal 10 bloodloss damage.
Made blood absorption solution deal 3 bloodloss damage.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
<!-- Зачем нужно это изменение? Прикрепите любые обсуждения или проблемы здесь. Опишите, как это повлияет на текущий баланс игры. -->
Currently only spells can heal this kind of damage this should be remedied. Also gives more a reason to carry blood healing potions.