### PR TITLE
Change healing to use EvenHealthChange

### DIFF
--- a/Resources/Prototypes/_CP14/Reagents/target_effects.yml
+++ b/Resources/Prototypes/_CP14/Reagents/target_effects.yml
@@ -25,10 +25,9 @@
       effects:
       - !type:ModifyBleedAmount
         amount: -2
-      - !type:HealthChange
+      - !type:EvenHealthChange
         damage:
-          groups:
-            Brute: -6
+          Brute: -6
   pricePerUnit: 2
 
 - type: reagent


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
<!-- Что вы изменили в своем пулл реквесте? -->
Changes Healing solution to use EvenHealthChange what this does is instead of the brute it heals being always split into each type of brute even if not present. With that value being 2 on each now instead of that if you have one type of brute it will heal 6 of it if there are 2 types it will heal 3 of each.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
<!-- Зачем нужно это изменение? Прикрепите любые обсуждения или проблемы здесь. Опишите, как это повлияет на текущий баланс игры. -->
Healing solution has always felt overshadowed in the healing department by cure wounds this changes that when it relates to a single type of brute is present.
