### PR TITLE
Furnace radius

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Structures/Specific/Blacksmith/furnace.yml
+++ b/Resources/Prototypes/_CP14/Entities/Structures/Specific/Blacksmith/furnace.yml
@@ -35,6 +35,7 @@
     radius: 2
     energy: 2
   - type: CP14Workbench
+    workbenchRadius: 0.5
     craftSound:
       collection: CP14Sawing #TODO
     recipeTags:


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
<!-- Что вы изменили в своем пулл реквесте? -->
Радиус печи возвращен до 0.5 (четко на 1-м тайле как раньше)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
<!-- Зачем нужно это изменение? Прикрепите любые обсуждения или проблемы здесь. Опишите, как это повлияет на текущий баланс игры. -->
Были жалобы что печка может "всосать рядом стоящие предметы"

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->
<!--
Пулл реквесты, которые несут за собой игровые изменения (добавления одежды, предметов и так далее) требуют чтобы вы прикрепили скриншоты или видеоролики, демонстрирующие эти изменения.
Небольшие исправления не считаются.
-->
