### PR TITLE
Removing The Scream Action From The Action Bar

### DIFF
--- a/Content.Server/Speech/EntitySystems/VocalSystem.cs
+++ b/Content.Server/Speech/EntitySystems/VocalSystem.cs
@@ -34,7 +34,7 @@ public sealed class VocalSystem : EntitySystem
     private void OnMapInit(EntityUid uid, VocalComponent component, MapInitEvent args)
     {
         // try to add scream action when vocal comp added
-        //_actions.AddAction(uid, ref component.ScreamActionEntity, component.ScreamAction); Commetet out to Remove The Scream Action from the Action bar
+        //_actions.AddAction(uid, ref component.ScreamActionEntity, component.ScreamAction); //CP14 Remove The Scream Action from the Action bar
         LoadSounds(uid, component);
     }
 

--- a/Content.Server/Speech/EntitySystems/VocalSystem.cs
+++ b/Content.Server/Speech/EntitySystems/VocalSystem.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Speech.EntitySystems;
 
 public sealed class VocalSystem : EntitySystem
 {
+
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
@@ -23,13 +24,30 @@ public sealed class VocalSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
+        SubscribeLocalEvent<VocalComponent, MapInitEvent>(OnMapInit);
+        //SubscribeLocalEvent<VocalComponent, ComponentShutdown>(OnShutdown); Commetet out along with Addiding the Scream Action as its not used at the moment
         SubscribeLocalEvent<VocalComponent, SexChangedEvent>(OnSexChanged);
         SubscribeLocalEvent<VocalComponent, EmoteEvent>(OnEmote);
         SubscribeLocalEvent<VocalComponent, ScreamActionEvent>(OnScreamAction);
     }
 
 
+    private void OnMapInit(EntityUid uid, VocalComponent component, MapInitEvent args)
+    {
+    //     // try to add scream action when vocal comp added
+    //     _actions.AddAction(uid, ref component.ScreamActionEntity, component.ScreamAction);
+    //     LoadSounds(uid, component);
+    // }
 
+    // private void OnShutdown(EntityUid uid, VocalComponent component, ComponentShutdown args)
+    // {
+    //     // remove scream action when component removed
+    //     if (component.ScreamActionEntity != null)
+    //     {
+    //         _actions.RemoveAction(uid, component.ScreamActionEntity);
+    //    }
+    }
+    //Commentet out to Remove Scream Action From the Action Bar
     private void OnSexChanged(EntityUid uid, VocalComponent component, SexChangedEvent args)
     {
         LoadSounds(uid, component, args.NewSex);

--- a/Content.Server/Speech/EntitySystems/VocalSystem.cs
+++ b/Content.Server/Speech/EntitySystems/VocalSystem.cs
@@ -43,7 +43,7 @@ public sealed class VocalSystem : EntitySystem
         // remove scream action when component removed
         if (component.ScreamActionEntity != null)
         {
-            //_actions.RemoveAction(uid, component.ScreamActionEntity); Commetet out to Remove The Scream Action from the Action bar
+            //_actions.RemoveAction(uid, component.ScreamActionEntity);  //CP14 Remove The Scream Action from the Action bar
         }
     }
 

--- a/Content.Server/Speech/EntitySystems/VocalSystem.cs
+++ b/Content.Server/Speech/EntitySystems/VocalSystem.cs
@@ -23,29 +23,12 @@ public sealed class VocalSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
-
-        SubscribeLocalEvent<VocalComponent, MapInitEvent>(OnMapInit);
-        SubscribeLocalEvent<VocalComponent, ComponentShutdown>(OnShutdown);
         SubscribeLocalEvent<VocalComponent, SexChangedEvent>(OnSexChanged);
         SubscribeLocalEvent<VocalComponent, EmoteEvent>(OnEmote);
         SubscribeLocalEvent<VocalComponent, ScreamActionEvent>(OnScreamAction);
     }
 
-    private void OnMapInit(EntityUid uid, VocalComponent component, MapInitEvent args)
-    {
-        // try to add scream action when vocal comp added
-        _actions.AddAction(uid, ref component.ScreamActionEntity, component.ScreamAction);
-        LoadSounds(uid, component);
-    }
 
-    private void OnShutdown(EntityUid uid, VocalComponent component, ComponentShutdown args)
-    {
-        // remove scream action when component removed
-        if (component.ScreamActionEntity != null)
-        {
-            _actions.RemoveAction(uid, component.ScreamActionEntity);
-        }
-    }
 
     private void OnSexChanged(EntityUid uid, VocalComponent component, SexChangedEvent args)
     {

--- a/Content.Server/Speech/EntitySystems/VocalSystem.cs
+++ b/Content.Server/Speech/EntitySystems/VocalSystem.cs
@@ -14,7 +14,6 @@ namespace Content.Server.Speech.EntitySystems;
 
 public sealed class VocalSystem : EntitySystem
 {
-
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
@@ -24,30 +23,30 @@ public sealed class VocalSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
+
         SubscribeLocalEvent<VocalComponent, MapInitEvent>(OnMapInit);
-        //SubscribeLocalEvent<VocalComponent, ComponentShutdown>(OnShutdown); Commetet out along with Addiding the Scream Action as its not used at the moment
+        SubscribeLocalEvent<VocalComponent, ComponentShutdown>(OnShutdown);
         SubscribeLocalEvent<VocalComponent, SexChangedEvent>(OnSexChanged);
         SubscribeLocalEvent<VocalComponent, EmoteEvent>(OnEmote);
         SubscribeLocalEvent<VocalComponent, ScreamActionEvent>(OnScreamAction);
     }
 
-
     private void OnMapInit(EntityUid uid, VocalComponent component, MapInitEvent args)
     {
-    //     // try to add scream action when vocal comp added
-    //     _actions.AddAction(uid, ref component.ScreamActionEntity, component.ScreamAction);
-    //     LoadSounds(uid, component);
-    // }
-
-    // private void OnShutdown(EntityUid uid, VocalComponent component, ComponentShutdown args)
-    // {
-    //     // remove scream action when component removed
-    //     if (component.ScreamActionEntity != null)
-    //     {
-    //         _actions.RemoveAction(uid, component.ScreamActionEntity);
-    //    }
+        // try to add scream action when vocal comp added
+        //_actions.AddAction(uid, ref component.ScreamActionEntity, component.ScreamAction); Commetet out to Remove The Scream Action from the Action bar
+        LoadSounds(uid, component);
     }
-    //Commentet out to Remove Scream Action From the Action Bar
+
+    private void OnShutdown(EntityUid uid, VocalComponent component, ComponentShutdown args)
+    {
+        // remove scream action when component removed
+        if (component.ScreamActionEntity != null)
+        {
+            //_actions.RemoveAction(uid, component.ScreamActionEntity); Commetet out to Remove The Scream Action from the Action bar
+        }
+    }
+
     private void OnSexChanged(EntityUid uid, VocalComponent component, SexChangedEvent args)
     {
         LoadSounds(uid, component, args.NewSex);


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
I removed The initizalition for the Scream Action, wich takes place as soon as the Map is initialization.
In addition the Subsciption To the Local Events For  "OnMapInit" and "Onshutdown" were removed as they are now nolonger used by the Vocal System


## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
#1212
#1214

:cl:
- remove: Removed the scream action from the hotbar. Yelling can still be done through the emotion wheel and chat. 

