### PR TITLE
Changed cashconverter to be anchorable on tables

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Structures/Specific/Economy/cash_converter.yml
+++ b/Resources/Prototypes/_CP14/Entities/Structures/Specific/Economy/cash_converter.yml
@@ -46,7 +46,5 @@
           bounds: "-0.4,-0.4,0.4,0.4"
         density: 190
         mask:
-        - MachineMask
-        layer:
-          - MachineLayer
+        - TabletopMachineMask
 


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Fixes #605, brings CP14CashConverter in line with CP14AlchemySolutionCleaner. That is, no player collision but anchorable with tables and doesn't go through walls. Someone with more experience with fixtures may be able to help with this.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Cash converters are intended to be anchor able on tables as shown by mapping and the issue.
## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Cash converters can be anchored on tables
