### PR TITLE
Ballade magic rework

### DIFF
--- a/Content.Shared/_CP14/MagicSpell/Spells/CP14SpellArea.cs
+++ b/Content.Shared/_CP14/MagicSpell/Spells/CP14SpellArea.cs
@@ -1,0 +1,64 @@
+using Content.Shared.Whitelist;
+using Robust.Shared.Map;
+
+namespace Content.Shared._CP14.MagicSpell.Spells;
+
+public sealed partial class CP14SpellArea : CP14SpellEffect
+{
+    [DataField(required: true)]
+    public List<CP14SpellEffect> Effects { get; set; } = new();
+
+    [DataField]
+    public EntityWhitelist? Whitelist;
+
+    /// <summary>
+    /// How many entities can be subject to EntityEffect? Leave 0 to remove the restriction.
+    /// </summary>
+    [DataField]
+    public int MaxTargets = 0;
+
+    [DataField(required: true)]
+    public float Range = 1f;
+
+    [DataField]
+    public bool AffectCaster = false;
+
+    public override void Effect(EntityManager entManager, CP14SpellEffectBaseArgs args)
+    {
+        EntityCoordinates? targetPoint = null;
+
+        if (args.Target is not null &&
+            entManager.TryGetComponent<TransformComponent>(args.Target.Value, out var transformComponent))
+            targetPoint = transformComponent.Coordinates;
+        else if (args.Position is not null)
+            targetPoint = args.Position;
+
+        if (targetPoint is null)
+            return;
+
+        var lookup = entManager.System<EntityLookupSystem>();
+        var whitelist = entManager.System<EntityWhitelistSystem>();
+
+        var entitiesAround = lookup.GetEntitiesInRange(targetPoint.Value, Range, LookupFlags.Uncontained);
+
+        var count = 0;
+        foreach (var entity in entitiesAround)
+        {
+            if (entity == args.User && !AffectCaster)
+                continue;
+
+            if (Whitelist is not null && !whitelist.IsValid(Whitelist, entity))
+                continue;
+
+            foreach (var effect in Effects)
+            {
+                effect.Effect(entManager, new CP14SpellEffectBaseArgs(args.User, null, entity,  targetPoint));
+            }
+
+            count++;
+
+            if (MaxTargets > 0 && count >= MaxTargets)
+                break;
+        }
+    }
+}

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/hell_ballade.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/hell_ballade.yml
@@ -13,9 +13,24 @@
   - type: CP14MagicEffect
     magicType: Fire
     effects:
-    - !type:CP14SpellSpawnEntityOnTarget
-      spawns:
-      - CP14AreaEntityEffectHellBallade
+    - !type:CP14SpellArea
+      range: 3
+      maxTargets: 4
+      whitelist:
+        components:
+        - MobState
+      effects:
+      - !type:CP14SpellSpawnEntityOnTarget
+        spawns:
+        - CP14ImpactEffectHellBallade
+      - !type:CP14SpellApplyEntityEffect
+        effects:
+        - !type:Jitter
+        - !type:FlammableReaction
+          multiplier: 0.5
+        - !type:AdjustTemperature
+          amount: 500
+        - !type:Ignite
   - type: CP14MagicEffectRequiredMusicTool
   - type: CP14MagicEffectCastingVisual
     proto: CP14RuneHellBallade
@@ -31,32 +46,6 @@
       cooldown: 15
       castTime: 120
       hidden: true
-
-- type: entity
-  id: CP14AreaEntityEffectHellBallade
-  categories: [ HideSpawnMenu ]
-  save: false
-  components:
-  - type: TimedDespawn
-    lifetime: 1.6
-  - type: CP14AreaEntityEffect
-    range: 3
-    maxTargets: 4
-    whitelist:
-      components:
-      - MobState
-    effects:
-    - !type:CP14SpellSpawnEntityOnTarget
-      spawns:
-      - CP14ImpactEffectHellBallade
-    - !type:CP14SpellApplyEntityEffect
-      effects:
-      - !type:Jitter
-      - !type:FlammableReaction
-        multiplier: 0.5
-      - !type:AdjustTemperature
-        amount: 500
-      - !type:Ignite
 
 - type: entity
   id: CP14ImpactEffectHellBallade
@@ -85,4 +74,3 @@
     - state: notes_3
       color: "#eea911"
       shader: unshaded
-

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/heal_ballade.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/heal_ballade.yml
@@ -13,9 +13,30 @@
   - type: CP14MagicEffect
     magicType: Life
     effects:
-    - !type:CP14SpellSpawnEntityOnTarget
-      spawns:
-      - CP14AreaEntityEffectHealBallade
+    - !type:CP14SpellArea
+      range: 3
+      maxTargets: 4
+      whitelist:
+        components:
+        - MobState
+      effects:
+      - !type:CP14SpellSpawnEntityOnTarget
+        spawns:
+        - CP14ImpactEffectHealthBallade
+      - !type:CP14SpellApplyEntityEffect
+        effects:
+        - !type:HealthChange
+          damage:
+            types:
+              Slash: -0.70
+              Blunt: -0.70
+              Piercing: -0.70
+              Cold: -0.40
+              Heat: -0.40
+              Shock: -0.40
+              Poison: -0.25
+              Bloodloss: -0.40
+              Caustic: -0.30
   - type: CP14MagicEffectRequiredMusicTool
   - type: CP14MagicEffectCastingVisual
     proto: CP14RuneHealBallade
@@ -31,38 +52,6 @@
       cooldown: 15
       castTime: 120
       hidden: true
-
-- type: entity
-  id: CP14AreaEntityEffectHealBallade
-  categories: [ HideSpawnMenu ]
-  save: false
-  components:
-  - type: TimedDespawn
-    lifetime: 1.6
-  - type: CP14AreaEntityEffect
-    range: 3
-    maxTargets: 4
-    whitelist:
-      components:
-      - MobState
-    effects:
-    - !type:CP14SpellSpawnEntityOnTarget
-      spawns:
-      - CP14ImpactEffectHealthBallade
-    - !type:CP14SpellApplyEntityEffect
-      effects:
-      - !type:HealthChange
-        damage:
-          types:
-            Slash: -0.70
-            Blunt: -0.70
-            Piercing: -0.70
-            Cold: -0.40
-            Heat: -0.40
-            Shock: -0.40
-            Poison: -0.25
-            Bloodloss: -0.40
-            Caustic: -0.30
 
 - type: entity
   id: CP14ImpactEffectHealthBallade

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/peace_ballade.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/peace_ballade.yml
@@ -13,9 +13,23 @@
   - type: CP14MagicEffect
     magicType: Life
     effects:
-    - !type:CP14SpellSpawnEntityOnTarget
-      spawns:
-      - CP14AreaEntityEffectPeaceBallade
+    - !type:CP14SpellArea
+      range: 4
+      maxTargets: 8
+      whitelist:
+        components:
+        - MobState
+      effects:
+      - !type:CP14SpellSpawnEntityOnTarget
+        spawns:
+        - CP14ImpactEffectPeaceBallade
+      - !type:CP14SpellApplyEntityEffect
+        effects:
+        - !type:GenericStatusEffect
+          key: Pacified
+          component: Pacified
+          type: Add
+          time: 1.8
   - type: CP14MagicEffectRequiredMusicTool
   - type: CP14MagicEffectCastingVisual
     proto: CP14RunePeaceBallade
@@ -31,31 +45,6 @@
       cooldown: 15
       castTime: 120
       hidden: true
-
-- type: entity
-  id: CP14AreaEntityEffectPeaceBallade
-  categories: [ HideSpawnMenu ]
-  save: false
-  components:
-  - type: TimedDespawn
-    lifetime: 1.6
-  - type: CP14AreaEntityEffect
-    range: 5
-    maxTargets: 8
-    whitelist:
-      components:
-      - MobState
-    effects:
-    - !type:CP14SpellSpawnEntityOnTarget
-      spawns:
-      - CP14ImpactEffectPeaceBallade
-    - !type:CP14SpellApplyEntityEffect
-      effects:
-      - !type:GenericStatusEffect
-        key: Pacified
-        component: Pacified
-        type: Add
-        time: 1.8
 
 - type: entity
   id: CP14ImpactEffectPeaceBallade

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/speed_ballade.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/speed_ballade.yml
@@ -13,9 +13,23 @@
   - type: CP14MagicEffect
     magicType: Life
     effects:
-    - !type:CP14SpellSpawnEntityOnTarget
-      spawns:
-      - CP14AreaEntityEffectSpeedBallade
+    - !type:CP14SpellArea
+      affectCaster: true
+      range: 5
+      maxTargets: 4
+      whitelist:
+        components:
+        - MobState
+      effects:
+      - !type:CP14SpellSpawnEntityOnTarget
+        spawns:
+        - CP14ImpactEffectSpeedBallade
+      - !type:CP14SpellApplyEntityEffect
+        effects:
+        - !type:MovespeedModifier
+          walkSpeedModifier: 1.2
+          sprintSpeedModifier: 1.2
+          statusLifetime: 1.8
   - type: CP14MagicEffectRequiredMusicTool
   - type: CP14MagicEffectCastingVisual
     proto: CP14RuneSpeedBallade
@@ -31,30 +45,6 @@
       cooldown: 15
       castTime: 120
       hidden: true
-
-- type: entity
-  id: CP14AreaEntityEffectSpeedBallade
-  categories: [ HideSpawnMenu ]
-  save: false
-  components:
-  - type: TimedDespawn
-    lifetime: 1.6
-  - type: CP14AreaEntityEffect
-    range: 3
-    maxTargets: 4
-    whitelist:
-      components:
-      - MobState
-    effects:
-    - !type:CP14SpellSpawnEntityOnTarget
-      spawns:
-      - CP14ImpactEffectSpeedBallade
-    - !type:CP14SpellApplyEntityEffect
-      effects:
-      - !type:MovespeedModifier
-        walkSpeedModifier: 1.15
-        sprintSpeedModifier: 1.15
-        statusLifetime: 1.8
 
 - type: entity
   id: CP14ImpactEffectSpeedBallade

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Meta/mana_ballade.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Meta/mana_ballade.yml
@@ -13,9 +13,22 @@
     canModifyManacost: false
   - type: CP14MagicEffect
     effects:
-    - !type:CP14SpellSpawnEntityOnTarget
-      spawns:
-      - CP14AreaEntityEffectMagicBallade
+    - !type:CP14SpellArea
+      range: 5
+      maxTargets: 5
+      whitelist:
+        components:
+        - CP14MagicEnergyContainer
+        - CP14MagicEnergyCrystalSlot
+      effects:
+      - !type:CP14SpellSpawnEntityOnTarget
+        spawns:
+        - CP14ImpactEffectMagicBallade
+      - !type:CP14SpellApplyEntityEffect
+        effects:
+        - !type:CP14ManaChange
+          manaDelta: 1.2
+          safe: true
   - type: CP14MagicEffectRequiredMusicTool
   - type: CP14MagicEffectCastingVisual
     proto: CP14RuneMagicBallade
@@ -31,30 +44,6 @@
       cooldown: 15
       castTime: 120
       hidden: true
-
-- type: entity
-  id: CP14AreaEntityEffectMagicBallade
-  categories: [ HideSpawnMenu ]
-  save: false
-  components:
-  - type: TimedDespawn
-    lifetime: 1.6
-  - type: CP14AreaEntityEffect
-    range: 5
-    maxTargets: 5
-    whitelist:
-      components:
-      - CP14MagicEnergyContainer
-      - CP14MagicEnergyCrystalSlot
-    effects:
-    - !type:CP14SpellSpawnEntityOnTarget
-      spawns:
-      - CP14ImpactEffectMagicBallade
-    - !type:CP14SpellApplyEntityEffect
-      effects:
-      - !type:CP14ManaChange
-        manaDelta: 1.2
-        safe: true
 
 - type: entity
   id: CP14ImpactEffectMagicBallade


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->

**Changelog**
:cl:
- tweak: Music magic no longer applies the effect on the musician. Tieflings with Hell Ballad are now OP
- tweak: The radius of action of the peace ballad has been increased by 2 times and the maximum number of entities that can be affected has been increased from 4 to 8
- tweak: The speed increase from the speed ballad is increased by 5%
