### PR TITLE
fix(objects): dropper size to tiny

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Objects/Specific/Alchemy/tools.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Specific/Alchemy/tools.yml
@@ -231,6 +231,8 @@
   - type: SolutionContainerVisuals
     maxFillLevels: 2
     fillBaseName: liq-
+  - type: Item
+    size: Tiny
 
 - type: entity
   id: CP14Syringe


### PR DESCRIPTION
## About the PR
Dropper size is back to tiny, same as upstream plus it makes more sense than it's current 2x1.

## Why / Balance
A dropper should be atleast as small as a small vial since it holds even less reagent.


**Changelog**
<!--
:cl:
- fix: dropper size is now 1x1
-->
