### PR TITLE
Starting reputation of merchants

### DIFF
--- a/Content.Server/_CP14/Trading/CP14TradingPlatformSystem.cs
+++ b/Content.Server/_CP14/Trading/CP14TradingPlatformSystem.cs
@@ -118,8 +118,8 @@ public sealed partial class CP14TradingPlatformSystem : CP14SharedTradingPlatfor
 
         if (indexedPosition.Service is not null)
             indexedPosition.Service.Buy(EntityManager, Proto, platform);
-        user.Comp.Reputation[indexedPosition.Faction] += (float)price / 100;
-        Dirty(user);
+
+        AddReputation(user, indexedPosition.Faction, (float)price / 100);
 
         _audio.PlayPvs(platform.Comp.BuySound, Transform(platform).Coordinates);
 

--- a/Content.Shared/_CP14/Trading/CP14AddGlobalReputationSpecial.cs
+++ b/Content.Shared/_CP14/Trading/CP14AddGlobalReputationSpecial.cs
@@ -1,0 +1,24 @@
+using Content.Shared._CP14.Trading.Prototypes;
+using Content.Shared._CP14.Trading.Systems;
+using Content.Shared.Roles;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._CP14.Trading;
+
+public sealed partial class CP14AddGlobalReputationSpecial : JobSpecial
+{
+    [DataField]
+    public float Reputation = 1f;
+
+    public override void AfterEquip(EntityUid mob)
+    {
+        var entMan = IoCManager.Resolve<IEntityManager>();
+        var protoMan = IoCManager.Resolve<IPrototypeManager>();
+        var tradeSys = entMan.System<CP14SharedTradingPlatformSystem>();
+
+        foreach (var faction in protoMan.EnumeratePrototypes<CP14TradingFactionPrototype>())
+        {
+            tradeSys.AddReputation(mob, faction, Reputation);
+        }
+    }
+}

--- a/Content.Shared/_CP14/Trading/Systems/CP14SharedTradingPlatformSystem.cs
+++ b/Content.Shared/_CP14/Trading/Systems/CP14SharedTradingPlatformSystem.cs
@@ -79,6 +79,20 @@ public abstract partial class CP14SharedTradingPlatformSystem : EntitySystem
 
         return true;
     }
+
+    public void AddReputation(Entity<CP14TradingReputationComponent?> user,
+        ProtoId<CP14TradingFactionPrototype> faction, float rep)
+    {
+        if (!Resolve(user.Owner, ref user.Comp, false))
+            return;
+
+        if (!user.Comp.Reputation.ContainsKey(faction))
+            user.Comp.Reputation.Add(faction, rep);
+        else
+            user.Comp.Reputation[faction] += rep;
+
+        Dirty(user);
+    }
 }
 
 [Serializable, NetSerializable]

--- a/Resources/Prototypes/_CP14/Roles/Jobs/Traders/merchant.yml
+++ b/Resources/Prototypes/_CP14/Roles/Jobs/Traders/merchant.yml
@@ -10,6 +10,8 @@
   requirements:
     - !type:OverallPlaytimeRequirement
       time: 3600 # 1 hours
+  special:
+    - !type:CP14AddGlobalReputationSpecial
 
 - type: startingGear
   id: CP14MerchantGear


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->

## Media
![image](https://github.com/user-attachments/assets/da3f0cab-19ff-4ae8-839e-0e81a2a28b11)

**Changelog**
:cl:
- tweak: All merchants now gain +1 reputation with each faction at the start of the round, greatly expanding their range of goods.