### PR TITLE
Hotfixes

### DIFF
--- a/Content.Server/_CP14/Trading/CP14TradingPlatformSystem.cs
+++ b/Content.Server/_CP14/Trading/CP14TradingPlatformSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server._CP14.Currency;
 using Content.Server._CP14.MagicEnergy;
 using Content.Server.Cargo.Systems;
+using Content.Server.Storage.Components;
 using Content.Shared._CP14.MagicEnergy;
 using Content.Shared._CP14.Trading.Components;
 using Content.Shared._CP14.Trading.Prototypes;
@@ -9,8 +10,10 @@ using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Placeable;
 using Content.Shared.Popups;
+using Content.Shared.Storage;
 using Content.Shared.Tag;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
 
 namespace Content.Server._CP14.Trading;
@@ -48,6 +51,14 @@ public sealed partial class CP14TradingPlatformSystem : CP14SharedTradingPlatfor
         foreach (var placed in itemPlacer.PlacedEntities)
         {
             if (HasComp<MobStateComponent>(placed))
+                continue;
+            if (HasComp<EntityStorageComponent>(placed))
+                continue;
+            if (HasComp<StorageComponent>(placed))
+                continue;
+
+            var proto = MetaData(placed).EntityPrototype;
+            if (proto != null && !proto.ID.StartsWith("CP14")) //Shitfix, we dont wanna sell anything vanilla (like mob organs)
                 continue;
 
             var placedPrice = _price.GetPrice(placed);

--- a/Content.Shared/_CP14/MagicEnergy/SharedCP14MagicEnergySystem.cs
+++ b/Content.Shared/_CP14/MagicEnergy/SharedCP14MagicEnergySystem.cs
@@ -105,6 +105,7 @@ public abstract class SharedCP14MagicEnergySystem : EntitySystem
 
         deltaEnergy = newEnergy - oldEnergy;
         ent.Comp.Energy = newEnergy;
+        Dirty(ent);
 
         if (oldEnergy != newEnergy)
             RaiseLocalEvent(ent, new CP14MagicEnergyLevelChangeEvent(oldEnergy, newEnergy, ent.Comp.MaxEnergy));
@@ -120,14 +121,7 @@ public abstract class SharedCP14MagicEnergySystem : EntitySystem
         if (!Resolve(ent, ref ent.Comp, false))
             return;
 
-        var oldEnergy = ent.Comp.Energy;
-
-        ent.Comp.Energy = 0;
-
-        if (oldEnergy != 0)
-            RaiseLocalEvent(ent, new CP14MagicEnergyLevelChangeEvent(oldEnergy, 0, ent.Comp.MaxEnergy));
-
-        UpdateMagicAlert((ent, ent.Comp));
+        ChangeEnergy(ent, -ent.Comp.Energy, out _, out _);
     }
 
     public void TransferEnergy(Entity<CP14MagicEnergyContainerComponent?> sender,

--- a/Resources/Prototypes/_CP14/Entities/Structures/Specific/Economy/trade_platform.yml
+++ b/Resources/Prototypes/_CP14/Entities/Structures/Specific/Economy/trade_platform.yml
@@ -6,6 +6,7 @@
   categories: [ ForkFiltered ]
   components:
   - type: Sprite
+    drawdepth: FloorTiles
     snapCardinals: true
     sprite: _CP14/Structures/Specific/Economy/buy_platform.rsi
     layers:
@@ -55,6 +56,7 @@
   categories: [ ForkFiltered ]
   components:
   - type: Sprite
+    drawdepth: FloorTiles
     snapCardinals: true
     sprite: _CP14/Structures/Specific/Economy/buy_platform.rsi
     layers:


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->

**Changelog**
:cl:
- fix: fixed mispredict with examining the amount of remaining energy in magic containers
- fix: Merchants can no longer sell organs and things in containers. Economy exploit hotfix
