### PR TITLE
Added more economy exploits

### DIFF
--- a/Content.Server/_CP14/Trading/CP14StationEconomySystem.Price.cs
+++ b/Content.Server/_CP14/Trading/CP14StationEconomySystem.Price.cs
@@ -1,4 +1,5 @@
 using Content.Server.Cargo.Systems;
+using Content.Shared._CP14.MagicEnergy.Components;
 using Content.Shared.Weapons.Melee;
 
 namespace Content.Server._CP14.Trading;
@@ -8,23 +9,29 @@ public sealed partial class CP14StationEconomySystem
     private void InitPriceEvents()
     {
         SubscribeLocalEvent<MeleeWeaponComponent, PriceCalculationEvent>(OnMeleeWeaponPriceCalculation);
+        SubscribeLocalEvent<CP14MagicEnergyContainerComponent, PriceCalculationEvent>(OnMagicEnergyPriceCalculation);
     }
 
     private void OnMeleeWeaponPriceCalculation(Entity<MeleeWeaponComponent> ent, ref PriceCalculationEvent args)
     {
-        //double price = 0;
-        //var dps = ent.Comp.Damage.GetTotal() * ent.Comp.AttackRate;
-        //if (dps <= 0)
-        //    return;
-//
-        //price += dps.Value;
-//
-        //if (ent.Comp.ResetOnHandSelected == false)
-        //    price *= 1.5; // If the weapon doesn't reset on hand selection, it's more valuable.
-//
-        //if (ent.Comp.AltDisarm)
-        //    price *= 1.5; // If the weapon has an alt disarm, it's more valuable.
-//
-        //args.Price += price * 0.1f;
+        double price = 0;
+        var dps = ent.Comp.Damage.GetTotal() * ent.Comp.AttackRate;
+        if (dps <= 0)
+            return;
+
+        price += dps.Value * ent.Comp.CPWeaponPrice;
+
+        if (ent.Comp.ResetOnHandSelected == false)
+            price *= 1.5; // If the weapon doesn't reset on hand selection, it's more valuable.
+
+        if (ent.Comp.AltDisarm)
+            price *= 1.5; // If the weapon has an alt disarm, it's more valuable.
+
+        args.Price += price * 0.1f;
+    }
+
+    private void OnMagicEnergyPriceCalculation(Entity<CP14MagicEnergyContainerComponent> ent, ref PriceCalculationEvent args)
+    {
+        args.Price += (double)(ent.Comp.Energy * 0.1f);
     }
 }

--- a/Content.Server/_CP14/Trading/CP14StationEconomySystem.cs
+++ b/Content.Server/_CP14/Trading/CP14StationEconomySystem.cs
@@ -49,9 +49,9 @@ public sealed partial class CP14StationEconomySystem : CP14SharedStationEconomyS
             switch (trade.Service)
             {
                 case CP14BuyItemsService buyItems:
-                    if (!_proto.TryIndex(buyItems.Product, out var indexedProduct))
-                        break;
-                    price += _price.GetEstimatedPrice(indexedProduct) * buyItems.Count;
+                    var tempEnt = Spawn(buyItems.Product); //we need to correctly rate items through price event to rate melee weapon damage, amount of magic energy, and so on.
+                    price += _price.GetPrice(tempEnt) * buyItems.Count;
+                    QueueDel(tempEnt);
                     break;
             }
 

--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -133,6 +133,12 @@ public sealed partial class MeleeWeaponComponent : Component
     [DataField]
     public float CPAnimationOffset = -1f;
 
+    /// <summary>
+    /// CrystallEdge economic - Copper coins per 1 DPS
+    /// </summary>
+    [DataField]
+    public double CPWeaponPrice = 0.05f;
+
     // Sounds
 
     /// <summary>

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/ice_dagger.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/ice_dagger.yml
@@ -61,6 +61,7 @@
     soundHit:
       collection: MetalThud
     cPAnimationLength: 0.25
+    cPWeaponPrice: 0
   - type: Clothing
     equipDelay: 0.25
     unequipDelay: 0.25


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->

**Changelog**
:cl:
- add: Magical energy in items now costs money again at the rate of 1 copper coin per 10 energy.
- add: Weapons are now automatically rated based on DPS
- tweak: Changed the product rating system in the shopping platform. Now modifiers of weapons, armor, magic energy and so on are taken into account there.

