### PR TITLE
Demiplanes now also Verify That the players arent SSD

### DIFF
--- a/Content.Server/_CP14/Demiplane/CP14DemiplaneSystem.Stabilization.cs
+++ b/Content.Server/_CP14/Demiplane/CP14DemiplaneSystem.Stabilization.cs
@@ -1,6 +1,7 @@
 using Content.Server.Body.Systems;
 using Content.Shared._CP14.Demiplane.Components;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.SSDIndicator;
 
 namespace Content.Server._CP14.Demiplane;
 
@@ -50,7 +51,8 @@ public sealed partial class CP14DemiplaneSystem
 
             if (stabilizedMaps.Contains(map.Value))
                 continue;
-
+            if (TryComp(uid, out SSDIndicatorComponent? ssd) && ssd.IsSSD)
+                continue;
             stabilizedMaps.Add(map.Value);
         }
 


### PR DESCRIPTION
## About the PR
I added a check That Uses the SSdIndecatorComponent, to make sure the player isnt afk amongst other htings

## Why / Balance
#569

:cl:
- tweak: Demiplanes Now Also End if All players are Dead or SSD
-->
