### PR TITLE
Fixed some misplaced recipes for Aventails and Greaves.

### DIFF
--- a/Resources/Prototypes/_CP14/Recipes/Workbench/Anvil/modular_aventail.yml
+++ b/Resources/Prototypes/_CP14/Recipes/Workbench/Anvil/modular_aventail.yml
@@ -9,7 +9,7 @@
   requirements:
   - !type:SkillRequired
     skills:
-    - CopperMelting
+    - IronMelting
   - !type:StackResource
     stack: CP14IronBar
     count: 1
@@ -23,7 +23,7 @@
   requirements:
   - !type:SkillRequired
     skills:
-    - CopperMelting
+    - GoldMelting
   - !type:StackResource
     stack: CP14GoldBar
     count: 1
@@ -51,7 +51,7 @@
   requirements:
   - !type:SkillRequired
     skills:
-    - CopperMelting
+    - MithrilMelting
   - !type:StackResource
     stack: CP14MithrilBar
     count: 1
@@ -67,7 +67,7 @@
   requirements:
   - !type:SkillRequired
     skills:
-    - CopperMelting
+    - IronMelting
   - !type:StackResource
     stack: CP14IronBar
     count: 1
@@ -81,7 +81,7 @@
   requirements:
   - !type:SkillRequired
     skills:
-    - CopperMelting
+    - GoldMelting
   - !type:StackResource
     stack: CP14GoldBar
     count: 1
@@ -109,7 +109,7 @@
   requirements:
   - !type:SkillRequired
     skills:
-    - CopperMelting
+    - MithrilMelting
   - !type:StackResource
     stack: CP14MithrilBar
     count: 1

--- a/Resources/Prototypes/_CP14/Recipes/Workbench/Anvil/modular_greave.yml
+++ b/Resources/Prototypes/_CP14/Recipes/Workbench/Anvil/modular_greave.yml
@@ -9,7 +9,7 @@
   requirements:
   - !type:SkillRequired
     skills:
-    - CopperMelting
+    - IronMelting
   - !type:StackResource
     stack: CP14IronBar
     count: 2
@@ -23,7 +23,7 @@
   requirements:
   - !type:SkillRequired
     skills:
-    - CopperMelting
+    - GoldMelting
   - !type:StackResource
     stack: CP14GoldBar
     count: 2


### PR DESCRIPTION
## About the PR
Fixed some misplaced recipes for Aventails and Greaves found in the Anvil

## Why / Balance
Because how could one learn how to make golden greaves from learning how to smelt and forge copper?

## Media
Forgot to grab photo of the misplaced recipes... Oops.

**Changelog**
:cl:
- fix: Iron, Gold and Mithril Aventails recipes to be at their respected metal category
- fix: Iron and Gold Greaves recipes to be at their respected metal category
