### PR TITLE
copper loadout fix

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/pickaxe.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/pickaxe.yml
@@ -24,6 +24,7 @@
     - state: icon
     - sprite: _CP14/Objects/ModularTools/Blade/Pickaxe/metall_pickaxe.rsi
       state: icon
+      color: "#e28f08"
   - type: CP14ModularCraftAutoAssemble
     details:
     - BladeCopperPickaxe

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/rapier.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/rapier.yml
@@ -24,6 +24,7 @@
     - state: icon
     - sprite: _CP14/Objects/ModularTools/Blade/Rapier/metall_rapier.rsi
       state: icon
+      color: "#e28f08"
   - type: CP14ModularCraftAutoAssemble
     details:
     - BladeCopperRapier

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/rapier.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/rapier.yml
@@ -16,7 +16,7 @@
 - type: entity
   id: CP14ModularCopperRapier
   parent: CP14ModularGripWooden
-  name: iron rapier
+  name: copper rapier
   description: You'll be lucky if it even pierces the paper.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/skimitar.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/skimitar.yml
@@ -24,6 +24,7 @@
     - state: icon
     - sprite: _CP14/Objects/ModularTools/Blade/Skimitar/metall_skimitar.rsi
       state: icon
+      color: "#e28f08"
   - type: CP14ModularCraftAutoAssemble
     details:
     - BladeCopperSkimitar

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/sword.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/sword.yml
@@ -16,7 +16,7 @@
 - type: entity
   id: CP14ModularCopperSword
   parent: CP14ModularGripWooden
-  name: iron sword
+  name: copper sword
   description: You'll be lucky if it even pierces the paper.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/sword.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/sword.yml
@@ -24,6 +24,7 @@
     - state: icon
     - sprite: _CP14/Objects/ModularTools/Blade/Sword/metall_sword.rsi
       state: icon
+      color: "#e28f08"
   - type: CP14ModularCraftAutoAssemble
     details:
     - BladeCopperSword


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Copper tools and weapons are now displayed correctly in loadout

