### PR TITLE
Big Crossbow Bolts to Quiver

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Clothing/Belt/quiver.yml
+++ b/Resources/Prototypes/_CP14/Entities/Clothing/Belt/quiver.yml
@@ -26,6 +26,7 @@
       tags:
       - CP14CrossbowBolt
       - CP14Arrow
+      - CP14BigCrossbowBolt
   - type: Appearance
   - type: StorageContainerVisuals
     maxFillLevels: 3
@@ -74,3 +75,14 @@
     contents:
       - id: CP14CrossboltIron
         amount: 32
+
+- type: entity
+  parent: CP14ClothingBeltQuiver
+  id: CP14ClothingBeltQuiverBigCrossbolt
+  categories: [ ForkFiltered ]
+  suffix: Full. Iron. BigCrossbolt
+  components:
+  - type: StorageFill
+    contents:
+    - id: CP14BigCrossboltIron
+      amount: 16


### PR DESCRIPTION
## About the PR
Added Big Crossbow Bolts to whitelist and created a new Entity spawn item for a quiver filled with iron big crossbow bolts.

Yes I am aware of the plans for the crossbow bolts to be combined into one once the issue ahead of it is resolved. This is a temporarily band-aid for those who want to use the 2h Crossbow in future runs.

## Why / Balance
If small bolts can be in quiver, why not big bolts? They are same size as arrows too.
Also added option for Admins to spawn in ghost roles with crossbows instead of bows to mix things up.

## Media
![Quiver Big Crossbow bolts](https://github.com/user-attachments/assets/f30b6151-36dc-4a52-b4b3-89e8f8c73936)
![Entity Spawn Panel Quiver](https://github.com/user-attachments/assets/795f0727-d9fb-4280-9a63-67d766d614a5)

**Changelog**
:cl:
- add: Added Quiver filled with Big Crossbow Bolts to Entity Spawn Menu for Admins/Testers
- fix: Fixed Quiver to hold Big Crossbow Bolts.
