### PR TITLE
Minor meat revisions

### DIFF
--- a/Resources/Locale/ru-RU/_CP14/_PROTO/entities/entities.ftl
+++ b/Resources/Locale/ru-RU/_CP14/_PROTO/entities/entities.ftl
@@ -1872,16 +1872,16 @@ ent-CP14FoodMeatPigSlice = кусочки мяса
 ent-CP14FoodMeatPigCookedSlice = кусочки приготовленного мяса
     .desc = { ent-CP14FoodMeatPigSlice.desc }
 
-ent-CP14FoodMeatMole = сырое мясо крота
+ent-CP14FoodMeatMole = сырое мясо монстра
     .desc = Цвет довольно подозрительный, не каждый решится его опробовать, может, отдать гоблину?
 
-ent-CP14FoodMeatMoleCooked = приготовленное мясо крота
+ent-CP14FoodMeatMoleCooked = приготовленное мясо монстра
     .desc = { ent-CP14FoodMeatMole.desc }
 
-ent-CP14FoodMeatMoleLeg = сырое мясо ноги крота
+ent-CP14FoodMeatMoleLeg = сырое мясо ноги монстра
     .desc = Подозрительный цвет мяса заставляет усомниться в его съедобности, но если вы действительно голодны...
 
-ent-CP14FoodMeatMoleLegCooked = приготовленное мясо ноги крота
+ent-CP14FoodMeatMoleLegCooked = приготовленное мясо ноги монстра
     .desc = { ent-CP14FoodMeatMoleLeg.desc }
 
 ent-CP14FoodMeatMoleSlice = кусочек мяса монстра

--- a/Resources/Prototypes/_CP14/Entities/Mobs/Player/DemiplaneAntag/lurker.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/Player/DemiplaneAntag/lurker.yml
@@ -76,7 +76,7 @@
   - type: Climbing
   - type: Butcherable
     spawned:
-    - id: CP14FoodMeatDino
+    - id: CP14FoodMeatMole
       amount: 4
     - id: CP14ClothingMaskBoneHornedMask
       amount: 1

--- a/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/meat.yml
@@ -747,12 +747,12 @@
     - temperatureRange: 400, 500
       transformTo: CP14Ash1
 
-# Mole Meat
+# Monster Meat
 
 - type: entity
   id: CP14FoodMeatMole
   parent: CP14FoodMeatBase
-  name: raw mole meat
+  name: raw monster meat
   description: The colour is quite suspicious, not everyone would dare to try it out, perhaps give it to a goblin?
   components:
   - type: Sprite
@@ -791,7 +791,7 @@
 - type: entity
   id: CP14FoodMeatMoleCooked
   parent: CP14FoodMeatMole
-  name: cooked mole meat
+  name: cooked monster meat
   components:
   - type: Sprite
     layers:
@@ -827,7 +827,7 @@
 - type: entity
   id: CP14FoodMeatMoleLeg
   parent: CP14FoodMeatBase
-  name: raw mole leg meat
+  name: raw monster leg meat
   description: The suspicious colour of the meat makes you question its edibility, but if you're really hungry...
   components:
   - type: Sprite
@@ -854,7 +854,7 @@
 - type: entity
   id: CP14FoodMeatMoleLegCooked
   parent: CP14FoodMeatMoleLeg
-  name: cooked mole leg meat # Jamon? - Хамон?
+  name: cooked monster leg meat # Jamon? - Хамон?
   components:
   - type: Sprite
     state: mole_meat5 # We need fried sprites


### PR DESCRIPTION
## About the PR

Mole meat has been renamed monster meat. Monster meat now drops from lurker, not dinosaur meat.
Мясо кротов переименовано в мясо монстров. С луркера теперь падает мясо монстров, а не динозавров.

## Why / Balance

Mole meat falls from all monsters, which is weird. Now it is common meat for all monsters.
Со всех монстров падает мясо кротов, что странно. Теперь это общее мясо для всех монстров.

**Changelog**

:cl:
- tweak: Changed the name of mole meat to monster meat.
