### PR TITLE
Lunar strike Rebalance

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Demigods/Lumera/moon_strike.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Demigods/Lumera/moon_strike.yml
@@ -5,7 +5,7 @@
   components:
   - type: CP14MagicEffectReligionRestricted
   - type: CP14MagicEffectManaCost
-    manaCost: 30
+    manaCost: 50
   - type: CP14MagicEffect
     effects:
     - !type:CP14SpellSpawnEntityOnTarget
@@ -20,7 +20,7 @@
       sprite: _CP14/Actions/DemigodSpells/lumera.rsi
       state: moon_beam
     event: !type:CP14WorldTargetActionEvent
-      cooldown: 0.5
+      cooldown: 10
 
 - type: entity
   id: CP14SkyLumeraStrike
@@ -58,7 +58,7 @@
       - !type:HealthChange
         damage:
           types:
-            Heat: 10
+            Heat: 30
   - type: TriggerOnSpawn
   - type: FlashOnTrigger
     range: 2

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Demigods/Lumera/moon_strike.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Demigods/Lumera/moon_strike.yml
@@ -5,7 +5,7 @@
   components:
   - type: CP14MagicEffectReligionRestricted
   - type: CP14MagicEffectManaCost
-    manaCost: 50
+    manaCost: 30
   - type: CP14MagicEffect
     effects:
     - !type:CP14SpellSpawnEntityOnTarget
@@ -20,7 +20,7 @@
       sprite: _CP14/Actions/DemigodSpells/lumera.rsi
       state: moon_beam
     event: !type:CP14WorldTargetActionEvent
-      cooldown: 10
+      cooldown: 15
 
 - type: entity
   id: CP14SkyLumeraStrike


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Changed Lunar strike to deal 30 heat damage from 10, and have a 15 second cooldown from 0.5 seconds.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Lunar strike's main power in pvp comes from the flash effect so giving it a larger cooldown will fix this while not completly gutting the spell for damage uses it still takes a minute now to send someone into crit from nothing.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Changed Lunar Strike to deal 30 heat damage from 10 and have a 15 second cooldown.