### PR TITLE
Lunar Strike nerf

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Demigods/Lumera/moon_strike.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Demigods/Lumera/moon_strike.yml
@@ -60,7 +60,7 @@
       - !type:HealthChange
         damage:
           types:
-            Heat: 30
+            Heat: 10
   - type: TriggerOnSpawn
   - type: FlashOnTrigger
     range: 2


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Reduce Lunar strikes damage down to 10 from 30

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I heard it was really oppressive with 30 damage last CBT so its getting reverted to 10.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Changed Lunar strike to deal 10 heat damage instead of 30.