### PR TITLE
Demiplane loop minor redesign

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Objects/Materials/misc.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Materials/misc.yml
@@ -90,9 +90,6 @@
   description: A fragment of the fabric of reality. An extremely valuable resource for those who know what they can do with it.
   categories: [ ForkFiltered ]
   components:
-  #- type: Tag
-  #  tags:
-  #  - CP14FitInMortar
   - type: Item
     size: Tiny
     shape:
@@ -111,4 +108,3 @@
         core2: ""
         core3: ""
         core4: ""
-


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Ядро демиплана теперь нельзя таскать за собой и вытаскивать наружу. 
Разрушение ядра демиплана засчитывает прохождение демиплана в любом случае
С ядра снова выпадают димнситовые осколки, и теперь они стоят по 1 серебрянной монете.

---

The core of the demiplane can no longer be dragged along and pulled out. 
Destroying the core of the demiplane counts as completing the demiplane in any case.
Dimension shards drop from the core again, and now they cost 1 silver coin each.

**Changelog**
:cl:
- add: Dimension shards drop from the core, and now they cost 1 silver coin each.
- tweak: The core of the demiplane can no longer be dragged along and pulled out. 
- tweak: Destroying the core of the demiplane counts as completing the demiplane in any case.

