### PR TITLE
Telegraph on lunar strike.

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Demigods/Lumera/moon_strike.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Demigods/Lumera/moon_strike.yml
@@ -8,6 +8,10 @@
   - type: CP14MagicEffectManaCost
     manaCost: 30
   - type: CP14MagicEffect
+    telegraphyEffects:
+    - !type:CP14SpellSpawnEntityOnTarget
+      spawns:
+      - CP14ImpactEffectMoonStrike
     effects:
     - !type:CP14SpellSpawnEntityOnTarget
       spawns:
@@ -21,8 +25,26 @@
     checkCanAccess: false
     range: 100
   - type: WorldTargetAction
-    event: !type:CP14WorldTargetActionEvent
-      cooldown: 15
+    event: !type:CP14DelayedWorldTargetActionEvent
+      cooldown: 25
+      castDelay: 1
+      breakOnMove: false
+
+- type: entity
+  id: CP14ImpactEffectMoonStrike
+  parent: CP14BaseMagicImpact
+  categories: [ HideSpawnMenu ]
+  save: false
+  components:
+  - type: Sprite
+    noRot: true
+    drawdepth: BelowFloor
+    sprite: _CP14/Effects/Magic/area_impact.rsi
+    layers:
+    - state: area_impact_out
+      color: "#7ca5d8"
+      scale: 2, 2
+      shader: unshaded
 
 - type: entity
   id: CP14SkyLumeraStrike
@@ -63,7 +85,7 @@
             Heat: 10
   - type: TriggerOnSpawn
   - type: FlashOnTrigger
-    range: 2
+    range: 1.5
   - type: CP14FarSound
     closeSound:
       collection: CP14MoonStrike


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Added a telegraph to lunar strike, made lunar strikes cooldown 25 seconds, reduced the flash radius on lunar strike to 1.5

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
lunar strike still too good 

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->
https://github.com/user-attachments/assets/a84eb1e7-07bd-4937-abe9-89d50bfa8300

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added a telegraph to Lunar strike with a cast time of 1 second.
- tweak: Changed Lunar strike to have a cooldown of 25 seconds, decrease the flash radius to 1.5 instead of 2.

