### PR TITLE
Automatic Modular items appraise

### DIFF
--- a/Content.Server/_CP14/MagicEnergy/CP14MagicEnergySystem.cs
+++ b/Content.Server/_CP14/MagicEnergy/CP14MagicEnergySystem.cs
@@ -1,4 +1,6 @@
 using Content.Shared._CP14.MagicEnergy;
+using Content.Shared._CP14.MagicEnergy.Components;
+using Content.Shared.Cargo;
 using Robust.Shared.Timing;
 
 namespace Content.Server._CP14.MagicEnergy;
@@ -14,6 +16,8 @@ public sealed partial class CP14MagicEnergySystem : SharedCP14MagicEnergySystem
 
         InitializeDraw();
         InitializePortRelay();
+
+        SubscribeLocalEvent<CP14MagicEnergyContainerComponent, PriceCalculationEvent>(OnMagicEnergyPriceCalculation);
     }
 
     public override void Update(float frameTime)
@@ -22,5 +26,10 @@ public sealed partial class CP14MagicEnergySystem : SharedCP14MagicEnergySystem
 
         UpdateDraw(frameTime);
         UpdatePortRelay(frameTime);
+    }
+
+    private void OnMagicEnergyPriceCalculation(Entity<CP14MagicEnergyContainerComponent> ent, ref PriceCalculationEvent args)
+    {
+        args.Price += (double)(ent.Comp.Energy * 0.1f);
     }
 }

--- a/Content.Server/_CP14/ModularCraft/CP14ModularCraftSystem.cs
+++ b/Content.Server/_CP14/ModularCraft/CP14ModularCraftSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Item;
 using Content.Shared._CP14.ModularCraft;
 using Content.Shared._CP14.ModularCraft.Components;
 using Content.Shared._CP14.ModularCraft.Prototypes;
+using Content.Shared.Cargo.Components;
 using Content.Shared.Throwing;
 using Content.Shared.Examine;
 using Content.Shared.Materials;
@@ -108,7 +109,13 @@ public sealed class CP14ModularCraftSystem : CP14SharedModularCraftSystem
         {
             foreach (var detail in autoAssemble.Details)
             {
-                TryAddPartToFirstSlot(ent, detail);
+                var detailEnt = Spawn(detail);
+                if (!TryComp<CP14ModularCraftPartComponent>(detailEnt, out var partComp))
+                {
+                    QueueDel(detailEnt);
+                    continue;
+                }
+                TryAddPartToFirstSlot(ent, (detailEnt, partComp));
             }
         }
     }
@@ -140,28 +147,8 @@ public sealed class CP14ModularCraftSystem : CP14SharedModularCraftSystem
         return false;
     }
 
-    private bool TryAddPartToFirstSlot(Entity<CP14ModularCraftStartPointComponent> start,
-        ProtoId<CP14ModularCraftPartPrototype> partProto)
-    {
-        if (!_proto.TryIndex(partProto, out var partIndexed))
-            return false;
-
-        if (partIndexed.Slots.Count == 0)
-            return false;
-
-        foreach (var slot in partIndexed.Slots)
-        {
-            if (!start.Comp.FreeSlots.Contains(slot))
-                continue;
-
-            return TryAddPartToSlot(start, null, partProto, slot);
-        }
-
-        return false;
-    }
-
     private bool TryAddPartToSlot(Entity<CP14ModularCraftStartPointComponent> start,
-        Entity<CP14ModularCraftPartComponent>? part,
+        Entity<CP14ModularCraftPartComponent> part,
         ProtoId<CP14ModularCraftPartPrototype> partProto,
         ProtoId<CP14ModularCraftSlotPrototype> slot)
     {
@@ -175,7 +162,7 @@ public sealed class CP14ModularCraftSystem : CP14SharedModularCraftSystem
     }
 
     private void AddPartToSlot(Entity<CP14ModularCraftStartPointComponent> start,
-        Entity<CP14ModularCraftPartComponent>? part,
+        Entity<CP14ModularCraftPartComponent> part,
         ProtoId<CP14ModularCraftPartPrototype> partProto,
         ProtoId<CP14ModularCraftSlotPrototype> slot)
     {
@@ -207,11 +194,13 @@ public sealed class CP14ModularCraftSystem : CP14SharedModularCraftSystem
             }
         }
 
-        if (TryComp<Shared.Cargo.Components.StaticPriceComponent>(part, out var staticPartPrice))
-        {
-            var startStaticPrice = EnsureComp<Shared.Cargo.Components.StaticPriceComponent>(start);
+        var startStaticPrice = EnsureComp<StaticPriceComponent>(start);
+        startStaticPrice.Price += part.Comp.AddPrice;
 
-            startStaticPrice.Price += staticPartPrice.Price;
+        if (TryComp<StaticPriceComponent>(part, out var partStaticPrice))
+        {
+
+            startStaticPrice.Price += partStaticPrice.Price;
         }
 
         foreach (var modifier in indexedPart.Modifiers)

--- a/Content.Server/_CP14/Trading/CP14StationEconomySystem.cs
+++ b/Content.Server/_CP14/Trading/CP14StationEconomySystem.cs
@@ -57,9 +57,9 @@ public sealed partial class CP14StationEconomySystem : CP14SharedStationEconomyS
             switch (trade.Service)
             {
                 case CP14BuyItemsService buyItems:
-                    if (!_proto.TryIndex(buyItems.Product, out var indexedProduct))
-                        break;
-                    price += _price.GetEstimatedPrice(indexedProduct) * buyItems.Count;
+                    var tempEnt = Spawn(buyItems.Product); //we need to correctly rate items through price event to rate melee weapon damage, amount of magic energy, and so on.
+                    price += _price.GetPrice(tempEnt) * buyItems.Count;
+                    QueueDel(tempEnt);
                     break;
             }
 

--- a/Content.Shared/_CP14/ModularCraft/Components/CP14ModularAutoAssembleComponent.cs
+++ b/Content.Shared/_CP14/ModularCraft/Components/CP14ModularAutoAssembleComponent.cs
@@ -10,5 +10,5 @@ namespace Content.Shared._CP14.ModularCraft.Components;
 public sealed partial class CP14ModularCraftAutoAssembleComponent : Component
 {
     [DataField]
-    public List<ProtoId<CP14ModularCraftPartPrototype>> Details = new();
+    public List<EntProtoId> Details = new();
 }

--- a/Content.Shared/_CP14/ModularCraft/Components/CP14ModularCraftPartComponent.cs
+++ b/Content.Shared/_CP14/ModularCraft/Components/CP14ModularCraftPartComponent.cs
@@ -12,5 +12,11 @@ public sealed partial class CP14ModularCraftPartComponent : Component
     [DataField]
     public float DoAfter = 1f;
 
+    /// <summary>
+    /// Attaching this piece adds an additional price to the target object.
+    /// </summary>
+    [DataField]
+    public double AddPrice = 5;
+
     //TODO: Sound
 }

--- a/Resources/Prototypes/_CP14/Entities/Clothing/ModularPresets/armour.yml
+++ b/Resources/Prototypes/_CP14/Entities/Clothing/ModularPresets/armour.yml
@@ -13,8 +13,8 @@
       state: icon
   - type: CP14ModularCraftAutoAssemble
     details:
-    - CuissesIronPlate
-    - GreaveIronPlate
+    - CP14ModularCuissesIronPlate
+    - CP14ModularGreaveIronPlate
 
 - type: entity
   id: CP14ArmorGoldCuirassPresets
@@ -34,8 +34,8 @@
       color: "#ffaf47"
   - type: CP14ModularCraftAutoAssemble
     details:
-    - CuissesGoldPlate
-    - GreaveGoldPlate
+    - CP14ModularCuissesGoldPlate
+    - CP14ModularGreaveGoldPlate
 
 - type: entity
   id: CP14ArmorCopperCuirassPresets
@@ -55,8 +55,8 @@
       color: "#bd712f"
   - type: CP14ModularCraftAutoAssemble
     details:
-    - CuissesCopperPlate
-    - GreaveCopperPlate
+    - CP14ModularCuissesCopperPlate
+    - CP14ModularGreaveCopperPlate
 
 - type: entity
   id: CP14ArmorMithrilCuirassPresets
@@ -76,8 +76,8 @@
       color: "#45d2a4"
   - type: CP14ModularCraftAutoAssemble
     details:
-    - CuissesMithrilPlate
-    - GreaveMithrilPlate
+    - CP14ModularCuissesMithrilPlate
+    - CP14ModularGreaveMithrilPlate
 
 - type: entity
   id: CP14ArmorIronChainmailPresets
@@ -94,8 +94,8 @@
       state: icon
   - type: CP14ModularCraftAutoAssemble
     details:
-    - CuissesIronChainmail
-    - GreaveIronChainmail
+    - CP14ModularCuissesIronChainmail
+    - CP14ModularGreaveIronChainmail
 
 - type: entity
   id: CP14ArmorMithrilChainmailPresets
@@ -115,5 +115,5 @@
       color: "#45d2a4"
   - type: CP14ModularCraftAutoAssemble
     details:
-    - CuissesMithrilChainmail
-    - GreaveMithrilChainmail
+    - CP14ModularCuissesMithrilChainmail
+    - CP14ModularGreaveMithrilChainmail

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/arrow.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/arrow.yml
@@ -12,7 +12,7 @@
       state: icon
   - type: CP14ModularCraftAutoAssemble
     details:
-    - TipIronArrow
+    - CP14ModularTipIronArrow
 
 - type: entity
   id: CP14ModularMithrilArrow
@@ -30,7 +30,7 @@
       color: "#45d2a4"
   - type: CP14ModularCraftAutoAssemble
     details:
-    - TipMithrilArrow
+    - CP14ModularTipMithrilArrow
 
 - type: entity
   id: CP14ModularCopperArrow
@@ -47,5 +47,5 @@
       color: "#bd712f"
   - type: CP14ModularCraftAutoAssemble
     details:
-    - TipCopperArrow
+    - CP14ModularTipCopperArrow
 

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/axe.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/axe.yml
@@ -11,5 +11,5 @@
       state: icon
   - type: CP14ModularCraftAutoAssemble
     details:
-    - BladeIronAxe
+    - CP14ModularBladeIronAxe
 

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/daggers.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/daggers.yml
@@ -11,4 +11,4 @@
       state: icon
   - type: CP14ModularCraftAutoAssemble
     details:
-    - BladeIronDagger
+    - CP14ModularBladeIronDagger

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/hammer.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/hammer.yml
@@ -11,5 +11,5 @@
       state: icon
   - type: CP14ModularCraftAutoAssemble
     details:
-    - BladeIronHammer
+    - CP14ModularBladeIronHammer
 

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/hoe.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/hoe.yml
@@ -11,5 +11,5 @@
       state: icon
   - type: CP14ModularCraftAutoAssemble
     details:
-    - BladeIronHoe
+    - CP14ModularBladeIronHoe
 

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/mace.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/mace.yml
@@ -11,5 +11,5 @@
       state: icon
   - type: CP14ModularCraftAutoAssemble
     details:
-    - BladeIronMace
+    - CP14ModularBladeIronMace
 

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/mop.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/mop.yml
@@ -11,4 +11,4 @@
       state: icon
   - type: CP14ModularCraftAutoAssemble
     details:
-    - BladeWoodMop
+    - CP14ModularBladeWoodMop

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/pickaxe.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/pickaxe.yml
@@ -11,7 +11,7 @@
       state: icon
   - type: CP14ModularCraftAutoAssemble
     details:
-    - BladeIronPickaxe
+    - CP14ModularBladeIronPickaxe
 
 - type: entity
   id: CP14ModularCopperPickaxe
@@ -27,4 +27,4 @@
       color: "#e28f08"
   - type: CP14ModularCraftAutoAssemble
     details:
-    - BladeCopperPickaxe
+    - CP14ModularBladeCopperPickaxe

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/rapier.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/rapier.yml
@@ -11,7 +11,7 @@
       state: icon
   - type: CP14ModularCraftAutoAssemble
     details:
-    - BladeIronRapier
+    - CP14ModularBladeIronRapier
 
 - type: entity
   id: CP14ModularCopperRapier
@@ -27,7 +27,7 @@
       color: "#e28f08"
   - type: CP14ModularCraftAutoAssemble
     details:
-    - BladeCopperRapier
+    - CP14ModularBladeCopperRapier
 
 - type: entity
   id: CP14ModularGuildmasterRapier
@@ -44,6 +44,6 @@
       state: icon
   - type: CP14ModularCraftAutoAssemble
     details:
-    - BladeIronRapier
-    - GardeGuildmaster
+    - CP14ModularBladeIronRapier
+    - CP14ModularGardeGuildmaster
 

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/shovel.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/shovel.yml
@@ -11,5 +11,5 @@
       state: icon
   - type: CP14ModularCraftAutoAssemble
     details:
-    - BladeIronShovel
+    - CP14ModularBladeIronShovel
 

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/sickle.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/sickle.yml
@@ -11,5 +11,5 @@
       state: icon
   - type: CP14ModularCraftAutoAssemble
     details:
-    - BladeIronSickle
+    - CP14ModularBladeIronSickle
 

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/skimitar.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/skimitar.yml
@@ -11,7 +11,7 @@
       state: icon
   - type: CP14ModularCraftAutoAssemble
     details:
-    - BladeIronSkimitar
+    - CP14ModularBladeIronSkimitar
 
 - type: entity
   id: CP14ModularCopperSkimitar
@@ -27,7 +27,7 @@
       color: "#e28f08"
   - type: CP14ModularCraftAutoAssemble
     details:
-    - BladeCopperSkimitar
+    - CP14ModularBladeCopperSkimitar
 
 - type: entity
   id: CP14ModularCopperSkimitarTundra
@@ -42,8 +42,8 @@
       state: icon
   - type: CP14ModularCraftAutoAssemble
     details:
-    - BladeCopperSkimitar
-    - InlayQuartzWater
+    - CP14ModularBladeCopperSkimitar
+    - CP14ModularInlayQuartzWater
 
 - type: entity
   id: CP14ModularGoldSkimitarAgony
@@ -58,5 +58,5 @@
       state: icon
   - type: CP14ModularCraftAutoAssemble
     details:
-    - BladeGoldSkimitar
-    - InlayQuartzElectric
+    - CP14ModularBladeGoldSkimitar
+    - CP14ModularInlayQuartzElectric

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/spear.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/spear.yml
@@ -11,7 +11,7 @@
       state: icon
   - type: CP14ModularCraftAutoAssemble
     details:
-    - BladeIronSpear
+    - CP14ModularBladeIronSpear
 
 - type: entity
   id: CP14ModularIronKunai
@@ -26,5 +26,5 @@
       state: icon
   - type: CP14ModularCraftAutoAssemble
     details:
-    - BladeIronSpear
+    - CP14ModularBladeIronSpear
 

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/sword.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/ModularPresets/sword.yml
@@ -11,7 +11,7 @@
       state: icon
   - type: CP14ModularCraftAutoAssemble
     details:
-    - BladeIronSword
+    - CP14ModularBladeIronSword
 
 - type: entity
   id: CP14ModularCopperSword
@@ -27,7 +27,7 @@
       color: "#e28f08"
   - type: CP14ModularCraftAutoAssemble
     details:
-    - BladeCopperSword
+    - CP14ModularBladeCopperSword
 
 - type: entity
   id: CP14ModularGuardHalberd
@@ -44,8 +44,8 @@
       state: icon
   - type: CP14ModularCraftAutoAssemble
     details:
-    - BladeIronSword
-    - GardeSharpIron
+    - CP14ModularBladeIronSword
+    - CP14ModularGardeSharpIron
 
 - type: entity
   id: CP14ModularSkeletonHalberd
@@ -60,7 +60,7 @@
       state: icon
   - type: CP14ModularCraftAutoAssemble
     details:
-    - BladeBoneSword
+    - CP14ModularBladeBoneSword
 
 - type: entity
   id: CP14ModularSkeletonSword
@@ -75,7 +75,7 @@
       state: icon
   - type: CP14ModularCraftAutoAssemble
     details:
-    - BladeBoneSword
+    - CP14ModularBladeBoneSword
 
 - type: entity
   id: CP14ModularSkeletonHalberdUpgrade
@@ -91,8 +91,8 @@
       state: icon
   - type: CP14ModularCraftAutoAssemble
     details:
-    - BladeBoneSword
-    - GardeSharpIron
+    - CP14ModularBladeBoneSword
+    - CP14ModularGardeSharpIron
 
 - type: entity
   id: CP14ModularSkeletonSwordUpgrade
@@ -108,6 +108,6 @@
       state: icon
   - type: CP14ModularCraftAutoAssemble
     details:
-    - BladeBoneSword
-    - GardeSharpIron
+    - CP14ModularBladeBoneSword
+    - CP14ModularGardeSharpIron
 


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->
![image](https://github.com/user-attachments/assets/c02155d3-5dcd-4ca4-9c64-90331121fe7e)

**Changelog**
:cl:
- add: Magical energy in items now costs money again at the rate of 1 copper coin per 10 energy.
- fix: Modular weapons and armor that have existed in the world since the beginning of the round are now priced correctly, and don't cost a couple of coppers.
