### PR TITLE
Added Executions for Non-Modular Weapon Base and Ice Dagger.

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/ice_dagger.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/ice_dagger.yml
@@ -135,6 +135,7 @@
         acts: ["Destruction"]
   - type: TimedDespawn
     lifetime: 60
+  - type: Execution
 
 - type: entity
   parent: CP14BaseSpellScrollWater

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/Melee/base.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/Melee/base.yml
@@ -83,6 +83,7 @@
     types:
       - Knife
   - type: CP14WallpaperRemover
+  - type: Execution
 
 - type: entity
   abstract: true
@@ -115,3 +116,18 @@
     damageToSelf:
       types:
         Blunt: 0.5 # 100 hits
+
+- type: entity
+  abstract: true
+  id: CP14BaseWeaponExecution
+  categories: [ HideSpawnMenu, ForkFiltered ]
+  components:
+  - type: Execution
+    internalMeleeExecutionMessage: "cp14-execution-popup-melee-initial-internal"
+    externalMeleeExecutionMessage: "cp14-execution-popup-melee-initial-external"
+    completeInternalMeleeExecutionMessage: "cp14-execution-popup-melee-complete-internal"
+    completeExternalMeleeExecutionMessage: "cp14-execution-popup-melee-complete-external"
+    internalSelfExecutionMessage: "cp14-execution-popup-self-initial-internal"
+    externalSelfExecutionMessage: "cp14-execution-popup-self-initial-external"
+    completeInternalSelfExecutionMessage: "cp14-execution-popup-self-complete-internal"
+    completeExternalSelfExecutionMessage: "cp14-execution-popup-self-complete-external"


### PR DESCRIPTION
## About the PR
Added leftover executions for Non-Modular weapons via CP14BaseWeaponSharp and CP14BaseWeaponExecution (for blunts) along with adding Execution components for Ice Dagger.

## Why / Balance
Forgor whenever making the executions. Whoops.

## Media
![image](https://github.com/user-attachments/assets/a2f1c9c8-35c3-4318-9cf7-13f66a6a7b7f)

**Changelog**
:cl:
- add: Executions for Ice Daggers.
- tweak: Non-Modular weapons can have execution verbs if added onto them.
