### PR TITLE
Mini update

### DIFF
--- a/Content.Server/_CP14/Trading/CP14PriceScannerSystem.cs
+++ b/Content.Server/_CP14/Trading/CP14PriceScannerSystem.cs
@@ -39,9 +39,10 @@ public sealed class CP14PriceScannerSystem : EntitySystem
         if (HasComp<MobStateComponent>(uid))
             return;
 
-        var getPrice = _price.GetPrice(args.Examined);
+        var price = Math.Round(_price.GetPrice(args.Examined));
 
-        var price = Math.Round(getPrice);
+        if (price <= 0)
+            return;
 
         var priceMsg = Loc.GetString("cp14-currency-examine-title");
 

--- a/Resources/Prototypes/_CP14/Skill/Demigods/lumera.yml
+++ b/Resources/Prototypes/_CP14/Skill/Demigods/lumera.yml
@@ -58,6 +58,20 @@
   - !type:NeedPrerequisite
     prerequisite: LumeraT1
 
+- type: cp14Skill
+  id: LumeraMagicVision
+  skillUiPosition: 2, 5
+  tree: GodLumera
+  icon:
+    sprite: _CP14/Actions/Spells/meta.rsi
+    state: magic_vision
+  effects:
+  - !type:AddAction
+    action: CP14ActionToggleMagicVision
+  restrictions:
+  - !type:NeedPrerequisite
+    prerequisite: LumeraT1
+
 # T2
 
 - type: cp14Skill

--- a/Resources/Prototypes/_CP14/Trading/SellRequests/thaumaturgy.yml
+++ b/Resources/Prototypes/_CP14/Trading/SellRequests/thaumaturgy.yml
@@ -8,53 +8,6 @@
     count: 5
 
 # 30 minutes
-- type: cp14TradingRequest
-  id: ThaumaturgyRuby
-  possibleFactions:
-  - Thaumaturgy
-  - Tailors
-  - DwarfMining
-  fromMinutes: 30
-  requirements:
-  - !type:ProtoIdResource
-    protoId: CP14JewelryRuby
-    count: 1
-
-- type: cp14TradingRequest
-  id: ThaumaturgyEmerald
-  possibleFactions:
-  - Thaumaturgy
-  - Tailors
-  - DwarfMining
-  fromMinutes: 30
-  requirements:
-  - !type:ProtoIdResource
-    protoId: CP14JewelryEmerald
-    count: 1
-
-- type: cp14TradingRequest
-  id: ThaumaturgySapphire
-  possibleFactions:
-  - Thaumaturgy
-  - Tailors
-  - DwarfMining
-  fromMinutes: 30
-  requirements:
-  - !type:ProtoIdResource
-    protoId: CP14JewelrySapphire
-    count: 1
-
-- type: cp14TradingRequest
-  id: ThaumaturgyTopaz
-  possibleFactions:
-  - Thaumaturgy
-  - Tailors
-  - DwarfMining
-  fromMinutes: 30
-  requirements:
-  - !type:ProtoIdResource
-    protoId: CP14JewelryTopaz
-    count: 1
 
 - type: cp14TradingRequest
   id: ThaumaturgyGoldAmulet


### PR DESCRIPTION
Introduces the LumeraMagicVision skill to the Lumera demigod skill tree, granting access to the Magic Vision action. Also removes several 30-minute jewelry trading requests (Ruby, Emerald, Sapphire, Topaz) from thaumaturgy.yml. Additionally, improves price scanner logic to skip items with non-positive price.

## About the PR
<!-- What did you change in this PR? -->

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->

**Changelog**
:cl:
- add: Lumera have T1 magical vision skill now!
- remove: Orders for precious stones have been removed, as they cannot be obtained in the game.
- tweak: The inscription “Market price: None” is no longer displayed on everything in a row if the object is worthless.
