### PR TITLE
Alchemist trading tweaks

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Objects/Specific/Alchemy/vials_filled_precursor.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Specific/Alchemy/vials_filled_precursor.yml
@@ -1,116 +1,116 @@
 - type: entity
   id: CP14VialBloodFlowerSap
-  parent: CP14VialSmall
+  parent: CP14VialMedium
   name: vial of blood rose sap
-  description: A tiny vial containing concentrated blood rose sap.
+  description: A medium vial containing concentrated blood rose sap.
   components:
   - type: SolutionContainerManager
     solutions:
       vial:
         reagents:
         - ReagentId: CP14BloodFlowerSap
-          Quantity: 10
+          Quantity: 50
 
 - type: entity
   id: CP14VialWildSageSap
-  parent: CP14VialSmall
+  parent: CP14VialMedium
   name: vial of wild sage sap
-  description: A tiny vial containing concentrated wild sage sap.
+  description: A medium vial containing concentrated wild sage sap.
   components:
   - type: SolutionContainerManager
     solutions:
       vial:
         reagents:
         - ReagentId: CP14WildSageSap
-          Quantity: 10
+          Quantity: 50
 
 - type: entity
   id: CP14VialYellowDayflinPulp
-  parent: CP14VialSmall
+  parent: CP14VialMedium
   name: vial of dayflin pulp
-  description: A tiny vial containing concentrated yellow dayflin pulp.
+  description: A medium vial containing concentrated yellow dayflin pulp.
   components:
   - type: SolutionContainerManager
     solutions:
       vial:
         reagents:
         - ReagentId: CP14YellowDayflinPulp
-          Quantity: 10
+          Quantity: 50
 
 - type: entity
   id: CP14VialBlueAmanita
-  parent: CP14VialSmall
+  parent: CP14VialMedium
   name: vial of blue amanita extract
-  description: A tiny vial containing concentrated blue amanita extract.
+  description: A medium vial containing concentrated blue amanita extract.
   components:
   - type: SolutionContainerManager
     solutions:
       vial:
         reagents:
         - ReagentId: CP14BlueAmanita
-          Quantity: 10
+          Quantity: 50
 
 - type: entity
   id: CP14VialLumiMushroom
-  parent: CP14VialSmall
+  parent: CP14VialMedium
   name: vial of lumishroom extract
-  description: A tiny vial containing concentrated lumishroom extract.
+  description: A medium vial containing concentrated lumishroom extract.
   components:
   - type: SolutionContainerManager
     solutions:
       vial:
         reagents:
         - ReagentId: CP14LumiMushroom
-          Quantity: 10
+          Quantity: 50
 
 - type: entity
   id: CP14VialSilverNeedle
-  parent: CP14VialSmall
+  parent: CP14VialMedium
   name: vial of silver needle extract
-  description: A tiny vial containing concentrated silver needle extract.
+  description: A medium vial containing concentrated silver needle extract.
   components:
   - type: SolutionContainerManager
     solutions:
       vial:
         reagents:
         - ReagentId: CP14SilverNeedle
-          Quantity: 10
+          Quantity: 50
 
 - type: entity
   id: CP14VialChromiumSlime
-  parent: CP14VialSmall
+  parent: CP14VialMedium
   name: vial of chromium slime
-  description: A tiny vial containing concentrated chromium slime.
+  description: A medium vial containing concentrated chromium slime.
   components:
   - type: SolutionContainerManager
     solutions:
       vial:
         reagents:
         - ReagentId: CP14ChromiumSlime
-          Quantity: 10
+          Quantity: 50
 
 - type: entity
   id: CP14VialAgaricMushroom
-  parent: CP14VialSmall
+  parent: CP14VialMedium
   name: vial of fly agaric extract
-  description: A tiny vial containing concentrated fly agaric extract.
+  description: A medium vial containing concentrated fly agaric extract.
   components:
   - type: SolutionContainerManager
     solutions:
       vial:
         reagents:
         - ReagentId: CP14AgaricMushroom
-          Quantity: 10
+          Quantity: 50
 
 - type: entity
   id: CP14VialAirLily
-  parent: CP14VialSmall
+  parent: CP14VialMedium
   name: vial of air lily extract
-  description: A tiny vial containing concentrated air lily extract.
+  description: A medium vial containing concentrated air lily extract.
   components:
   - type: SolutionContainerManager
     solutions:
       vial:
         reagents:
         - ReagentId: CP14AirLily
-          Quantity: 10
+          Quantity: 50

--- a/Resources/Prototypes/_CP14/Entities/Objects/Specific/Alchemy/vials_filled_precursor.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Specific/Alchemy/vials_filled_precursor.yml
@@ -9,7 +9,7 @@
       vial:
         reagents:
         - ReagentId: CP14BloodFlowerSap
-          Quantity: 5
+          Quantity: 10
 
 - type: entity
   id: CP14VialWildSageSap
@@ -22,7 +22,7 @@
       vial:
         reagents:
         - ReagentId: CP14WildSageSap
-          Quantity: 5
+          Quantity: 10
 
 - type: entity
   id: CP14VialYellowDayflinPulp
@@ -35,7 +35,7 @@
       vial:
         reagents:
         - ReagentId: CP14YellowDayflinPulp
-          Quantity: 5
+          Quantity: 10
 
 - type: entity
   id: CP14VialBlueAmanita
@@ -48,7 +48,7 @@
       vial:
         reagents:
         - ReagentId: CP14BlueAmanita
-          Quantity: 5
+          Quantity: 10
 
 - type: entity
   id: CP14VialLumiMushroom
@@ -61,7 +61,7 @@
       vial:
         reagents:
         - ReagentId: CP14LumiMushroom
-          Quantity: 5
+          Quantity: 10
 
 - type: entity
   id: CP14VialSilverNeedle
@@ -74,7 +74,7 @@
       vial:
         reagents:
         - ReagentId: CP14SilverNeedle
-          Quantity: 5
+          Quantity: 10
 
 - type: entity
   id: CP14VialChromiumSlime
@@ -87,7 +87,7 @@
       vial:
         reagents:
         - ReagentId: CP14ChromiumSlime
-          Quantity: 5
+          Quantity: 10
 
 - type: entity
   id: CP14VialAgaricMushroom
@@ -100,7 +100,7 @@
       vial:
         reagents:
         - ReagentId: CP14AgaricMushroom
-          Quantity: 5
+          Quantity: 10
 
 - type: entity
   id: CP14VialAirLily
@@ -113,4 +113,4 @@
       vial:
         reagents:
         - ReagentId: CP14AirLily
-          Quantity: 5
+          Quantity: 10

--- a/Resources/Prototypes/_CP14/Entities/Objects/Specific/Alchemy/vials_filled_precursor.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Specific/Alchemy/vials_filled_precursor.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: CP14VialBloodFlowerSap
-  parent: CP14VialTiny
+  parent: CP14VialSmall
   name: vial of blood rose sap
   description: A tiny vial containing concentrated blood rose sap.
   components:
@@ -13,7 +13,7 @@
 
 - type: entity
   id: CP14VialWildSageSap
-  parent: CP14VialTiny
+  parent: CP14VialSmall
   name: vial of wild sage sap
   description: A tiny vial containing concentrated wild sage sap.
   components:
@@ -26,7 +26,7 @@
 
 - type: entity
   id: CP14VialYellowDayflinPulp
-  parent: CP14VialTiny
+  parent: CP14VialSmall
   name: vial of dayflin pulp
   description: A tiny vial containing concentrated yellow dayflin pulp.
   components:
@@ -39,7 +39,7 @@
 
 - type: entity
   id: CP14VialBlueAmanita
-  parent: CP14VialTiny
+  parent: CP14VialSmall
   name: vial of blue amanita extract
   description: A tiny vial containing concentrated blue amanita extract.
   components:
@@ -52,7 +52,7 @@
 
 - type: entity
   id: CP14VialLumiMushroom
-  parent: CP14VialTiny
+  parent: CP14VialSmall
   name: vial of lumishroom extract
   description: A tiny vial containing concentrated lumishroom extract.
   components:
@@ -65,7 +65,7 @@
 
 - type: entity
   id: CP14VialSilverNeedle
-  parent: CP14VialTiny
+  parent: CP14VialSmall
   name: vial of silver needle extract
   description: A tiny vial containing concentrated silver needle extract.
   components:
@@ -78,7 +78,7 @@
 
 - type: entity
   id: CP14VialChromiumSlime
-  parent: CP14VialTiny
+  parent: CP14VialSmall
   name: vial of chromium slime
   description: A tiny vial containing concentrated chromium slime.
   components:
@@ -91,7 +91,7 @@
 
 - type: entity
   id: CP14VialAgaricMushroom
-  parent: CP14VialTiny
+  parent: CP14VialSmall
   name: vial of fly agaric extract
   description: A tiny vial containing concentrated fly agaric extract.
   components:
@@ -104,7 +104,7 @@
 
 - type: entity
   id: CP14VialAirLily
-  parent: CP14VialTiny
+  parent: CP14VialSmall
   name: vial of air lily extract
   description: A tiny vial containing concentrated air lily extract.
   components:

--- a/Resources/Prototypes/_CP14/Reagents/precurser.yml
+++ b/Resources/Prototypes/_CP14/Reagents/precurser.yml
@@ -41,12 +41,6 @@
         damage:
           groups:
             Airloss: -2
-    Poison:
-      effects:
-      - !type:HealthChange
-        damage:
-          types:
-            Poison: 0.6
       - !type:Emote
         showInChat: false
         emote: Cough
@@ -149,12 +143,6 @@
         damage:
           types:
             CP14ManaDepletion: -0.5
-    Poison:
-      effects:
-      - !type:HealthChange
-        damage:
-          types:
-            Poison: 0.1
   pricePerUnit: 0.86
 
 - type: reagent
@@ -171,13 +159,7 @@
       - !type:HealthChange
         damage:
           types:
-            Cold: -0.5
-    Poison:
-      effects:
-      - !type:HealthChange
-        damage:
-          types:
-            Poison: 0.1
+            Cold: -1
   pricePerUnit: 1.20
 
 # Slime based
@@ -210,11 +192,6 @@
   flavor: CP14Quartz
   color: "#9aa6ad"
   physicalDesc: cp14-reagent-physical-desc-colorless
-  metabolisms:
-    Food:
-      effects:
-      - !type:ChemVomit
-        probability: 0.05
   pricePerUnit: 0.15
 
 - type: reagent

--- a/Resources/Prototypes/_CP14/Trading/BuyPositions/horticulture.yml
+++ b/Resources/Prototypes/_CP14/Trading/BuyPositions/horticulture.yml
@@ -113,6 +113,18 @@
     count: 1
 
 - type: cp14TradingPosition
+  id: CP14VialAgaricMushroom
+  faction: Horticulture
+  reputationLevel: 1
+  uiPosition: 2
+  icon:
+    sprite: _CP14/Objects/Flora/Wild/agaric.rsi
+    state: base3
+  service: !type:CP14BuyItemsService
+    product: CP14VialAgaricMushroom
+    count: 1
+
+- type: cp14TradingPosition
   id: CP14ModularIronSickle
   faction: Horticulture
   reputationLevel: 1


### PR DESCRIPTION

:cl:
- add: Added missing fly agaric juice purchase position
- tweak: All raw precursor reagent purchase postiions are now sold in 50u vials rather than 5u. The price has also increased significantly
- tweak: Most raw plants that can be harvested in the world no longer deal poison damage and can be used as ghetto methods to treat different types of damage
