### PR TITLE
Monster blood

### DIFF
--- a/Resources/Locale/en-US/_CP14/reagents/meta/consumable/food/ingredients.ftl
+++ b/Resources/Locale/en-US/_CP14/reagents/meta/consumable/food/ingredients.ftl
@@ -1,2 +1,5 @@
 cp14-reagent-name-burnt-food = burnt food
 cp14-reagent-desc-burnt-food = A burnt and smoke-smelling black substance.
+
+cp14-reagent-name-taikamyrky = taikamyrky
+cp14-reagent-desc-taikamyrky = A viscous organic substance with a violet colour.

--- a/Resources/Locale/en-US/_CP14/reagents/meta/thaumaturgy/precurser.ftl
+++ b/Resources/Locale/en-US/_CP14/reagents/meta/thaumaturgy/precurser.ftl
@@ -16,6 +16,9 @@ cp14-reagent-desc-blood-elf = The life energy of a magical creature.
 cp14-reagent-name-blood-goblin = Goblin blood
 cp14-reagent-desc-blood-goblin = The life energy of green-skinned creatures.
 
+cp14-reagent-name-blood-monster = Monster blood
+cp14-reagent-desc-blood-monster = The life energy of various monsters.
+
 cp14-reagent-name-bloodflowersap = Bloodrose nectar
 cp14-reagent-desc-bloodflowersap = The nectar of the bloody flowers that grow in former battlefields. When properly mixed with blood, it can produce interesting results.
 

--- a/Resources/Locale/ru-RU/_CP14/reagents/meta/consumable/food/ingredients.ftl
+++ b/Resources/Locale/ru-RU/_CP14/reagents/meta/consumable/food/ingredients.ftl
@@ -1,2 +1,5 @@
 cp14-reagent-name-burnt-food = сгоревшая еда
 cp14-reagent-desc-burnt-food = Обгоревшая и пахнущая дымом черная субстанция.
+
+cp14-reagent-name-taikamyrky = тайкамурку
+cp14-reagent-desc-taikamyrky = Вязкое органическое вещество фиолетового оттенка.

--- a/Resources/Locale/ru-RU/_CP14/reagents/meta/thaumaturgy/precurser.ftl
+++ b/Resources/Locale/ru-RU/_CP14/reagents/meta/thaumaturgy/precurser.ftl
@@ -16,6 +16,9 @@ cp14-reagent-desc-blood-elf = Жизненная энергия волшебно
 cp14-reagent-name-blood-goblin = Кровь гоблина
 cp14-reagent-desc-blood-goblin = Жизненная энергия зеленокожих существ.
 
+cp14-reagent-name-blood-monster = Кровь монстра
+cp14-reagent-desc-blood-monster = Жизненная энергия различных монстров.
+
 cp14-reagent-name-bloodflowersap = Нектар кровавых роз
 cp14-reagent-desc-bloodflowersap = Сок кровавых цветов, растущих в местах былых битв. При правильном смешивании с кровью, может давать интересные результаты.
 

--- a/Resources/Prototypes/_CP14/Entities/Mobs/NPC/invisible_whistler.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/NPC/invisible_whistler.yml
@@ -75,7 +75,7 @@
       prob: 0.7
   - type: Bloodstream
     bloodMaxVolume: 200
-    bloodReagent: CP14BloodAnimal
+    bloodReagent: CP14BloodMonster
   - type: Grammar
     attributes:
       gender: epicene

--- a/Resources/Prototypes/_CP14/Entities/Mobs/NPC/mole.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/NPC/mole.yml
@@ -81,7 +81,7 @@
       prob: 0.6
   - type: Bloodstream
     bloodMaxVolume: 200
-    bloodReagent: CP14BloodAnimal
+    bloodReagent: CP14BloodMonster
   - type: Grammar
     attributes:
       gender: epicene

--- a/Resources/Prototypes/_CP14/Entities/Mobs/NPC/spider.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/NPC/spider.yml
@@ -76,7 +76,7 @@
   - type: IgnoreSpiderWeb
   - type: Bloodstream
     bloodMaxVolume: 150
-    bloodReagent: CP14BloodAnimal
+    bloodReagent: CP14BloodMonster
   - type: Speech
     speechVerb: Arachnid
     speechSounds: Arachnid

--- a/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Food/meat.yml
@@ -784,8 +784,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 20 # Add a reagent that restores mana, possibly poisonous
+        maxVol: 20
         reagents:
+        - ReagentId: CP14Taikamyrky
+          Quantity: 2
         - ReagentId: Nutriment
           Quantity: 2
         - ReagentId: UncookedAnimalProteins
@@ -820,7 +822,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 20 # Add a reagent that restores mana, if heated, perhaps change the composition of the reagent
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 6
@@ -854,8 +856,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 20 # Add a reagent that restores mana, possibly poisonous
+        maxVol: 20
         reagents:
+        - ReagentId: CP14Taikamyrky
+          Quantity: 2
         - ReagentId: Nutriment
           Quantity: 3.25
         - ReagentId: UncookedAnimalProteins
@@ -878,7 +882,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 20 # Add a reagent that restores mana, if heated, perhaps change the composition of the reagent
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 8
@@ -906,8 +910,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 5 # Add a reagent that restores mana, possibly poisonous
+        maxVol: 5
         reagents:
+        - ReagentId: CP14Taikamyrky
+          Quantity: 0.5
         - ReagentId: Nutriment
           Quantity: 0.5
         - ReagentId: UncookedAnimalProteins

--- a/Resources/Prototypes/_CP14/Reagents/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/_CP14/Reagents/Consumable/Food/ingredients.yml
@@ -3,7 +3,7 @@
   name: cp14-reagent-name-burnt-food
   group: Foods
   desc: cp14-reagent-desc-burnt-food
-  physicalDesc: reagent-physical-desc-powdery
+  physicalDesc: cp14-reagent-physical-desc-powdery
   flavor: terrible
   color: black
   recognizable: true
@@ -20,3 +20,25 @@
         - !type:ReagentThreshold
           min: 3
         probability: 0.3
+
+- type: reagent
+  id: CP14Taikamyrky
+  name: cp14-reagent-name-taikamyrky
+  group: Foods
+  desc: cp14-reagent-desc-taikamyrky
+  physicalDesc: cp14-reagent-physical-desc-viscous
+  flavor: terrible
+  color: "#6d00a3"
+  recognizable: true
+  metabolisms:
+    Food:
+      effects:
+      - !type:CP14ManaChange
+        manaDelta: 2
+      - !type:HealthChange
+        probability: 0.5
+        damage:
+          types:
+            CP14ManaDepletion: 2
+            Poison: 1
+      - !type:SatiateHunger

--- a/Resources/Prototypes/_CP14/Reagents/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/_CP14/Reagents/Consumable/Food/ingredients.yml
@@ -34,11 +34,12 @@
     Food:
       effects:
       - !type:CP14ManaChange
-        manaDelta: 2
+        manaDelta: -3
+        safe: false
       - !type:HealthChange
         probability: 0.5
         damage:
           types:
-            CP14ManaDepletion: 2
-            Poison: 1
+            CP14ManaDepletion: -0.5
+            Poison: 0.5
       - !type:SatiateHunger

--- a/Resources/Prototypes/_CP14/Reagents/blood.yml
+++ b/Resources/Prototypes/_CP14/Reagents/blood.yml
@@ -210,3 +210,45 @@
         statusLifetime: 1.5
   pricePerUnit: 0.05
 
+- type: reagent
+  id: CP14BloodMonster
+  group: CP14Precurser
+  name: cp14-reagent-name-blood-monster
+  desc: cp14-reagent-desc-blood-monster
+  flavor: CP14Metallic
+  color: "#800058"
+  recognizable: true
+  physicalDesc: cp14-reagent-physical-desc-ferrous
+  footstepSound:
+    collection: FootstepBlood
+    params:
+      volume: 6
+  metabolisms:
+    Food:
+      effects:
+      - !type:SatiateHunger
+        conditions:
+        - !type:OrganType
+          type: CP14Vampire
+      - !type:SatiateThirst
+        conditions:
+        - !type:OrganType
+          type: CP14Vampire
+    Medicine:
+      effects:
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: CP14Vampire
+        damage:
+          types:
+            CP14ManaDepletion: -5
+    Poison:
+      effects:
+      - !type:CP14ManaChange
+        manaDelta: 1
+      - !type:HealthChange
+        damage:
+          types:
+            CP14ManaDepletion: 1
+  pricePerUnit: 0.30


### PR DESCRIPTION
## About the PR

Adds its own type of magical blood to monsters, which tends to deal damage with magic depletion but replenishes mana. Also adds a separate nutrient to monster meat that reduces mana but cures mana depletion.
Добавляет монстрам собственный тип магической крови, которая имеет свойство наносить урон магическим истощением, но пополняет ману. Так же добавляет отдельное питательное вещество в мясо монстров, которое уменьшает ману, но лечит манаистощение.

## Why / Balance

Despite having some special properties, monsters were just like normal animals, having the same blood and meat. Now they have a more unique and special build that can also be used if desired.
Не смотря на некоторые особые свойства, монстры были такие же как и обычные животные, имея ту же кровь и мясо. Теперь они имеют более уникальное и особое строение, которое при желании тоже можно использовать.

**Changelog**

:cl:
- add: Adds its own type of blood to monsters, replenishing mana but inflicting mana depletion.
- add: Adds a special substance to the raw meat of monsters that inflicts poisons and wastes mana, but cures mana depletion.
