### PR TITLE
Adds kick whitelist

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Athletic/kick.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Athletic/kick.yml
@@ -46,6 +46,11 @@
       distanceThreshold: 1.5
       breakOnMove: false
       breakOnDamage: false
+  whitelist:
+    components:
+    - Body
+    - Item
+    - Anchorable
 
 - type: entity
   id: CP14DustEffectKickSound


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Adds a whitelist to kick so that you cant kick everything
resolves #1454 
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Beieng able to kick solid walls and puddles was probably not intended
## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->

https://github.com/user-attachments/assets/d45ee665-de03-4572-891e-3281b829a437


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: You can no longer kick anything

