### PR TITLE
Saturating and moisture recipes

### DIFF
--- a/Resources/Locale/en-US/_CP14/magicEnergy/magic-types.ftl
+++ b/Resources/Locale/en-US/_CP14/magicEnergy/magic-types.ftl
@@ -19,6 +19,7 @@ cp14-essence-crystal = Vitreus
 
 # Complex tier 2
 cp14-essence-magic = Praecantatio
+cp14-essence-beast = Bestia
 
 cp14-magic-manacost = Manacost
 cp14-magic-essence = Magic type

--- a/Resources/Locale/en-US/_CP14/reagents/meta/thaumaturgy/essence.ftl
+++ b/Resources/Locale/en-US/_CP14/reagents/meta/thaumaturgy/essence.ftl
@@ -24,7 +24,7 @@ cp14-reagent-name-essence-frost = Gelum essence
 cp14-reagent-desc-essence-frost = The liquid embodiment of the elements of ice, frost and cold.
 
 cp14-reagent-name-essence-light = Lux essence
-cp14-reagent-desc-essence-light = The liquid embodiment of the elements of light.
+cp14-reagent-desc-essence-light = The liquid embodiment of the element of light.
 
 cp14-reagent-name-essence-motion = Motus essence
 cp14-reagent-desc-essence-motion = The liquid embodiment of the elements of movement and animation.
@@ -51,3 +51,6 @@ cp14-reagent-desc-essence-crystal = The liquid embodiment of the elements of gla
 
 cp14-reagent-name-essence-magic = Praecantatio essence
 cp14-reagent-desc-essence-magic = The liquid embodiment of the elements of magic, enchantment and sorcery.
+
+cp14-reagent-name-essence-beast = Bestia essence
+cp14-reagent-desc-essence-beast = The liquid embodiment of the element of animals.

--- a/Resources/Locale/ru-RU/_CP14/magicEnergy/magic-types.ftl
+++ b/Resources/Locale/ru-RU/_CP14/magicEnergy/magic-types.ftl
@@ -19,6 +19,7 @@ cp14-essence-crystal = Vitreus
 
 # Complex tier 2
 cp14-essence-magic = Praecantatio
+cp14-essence-beast = Bestia
 
 cp14-magic-manacost = Затраты маны
 cp14-magic-essence = Тип магии

--- a/Resources/Locale/ru-RU/_CP14/reagents/meta/thaumaturgy/essence.ftl
+++ b/Resources/Locale/ru-RU/_CP14/reagents/meta/thaumaturgy/essence.ftl
@@ -51,3 +51,6 @@ cp14-reagent-desc-essence-crystal = Жидкое воплощение стихи
 
 cp14-reagent-name-essence-magic = Эссенция Praecantatio
 cp14-reagent-desc-essence-magic = Жидкое воплощение магии, чар и колдовства.
+
+cp14-reagent-name-essence-beast = Эссенция Bestia
+cp14-reagent-desc-essence-beast = Жидкое воплощение животных.

--- a/Resources/Prototypes/_CP14/Entities/Objects/Specific/Thaumaturgy/essence.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Specific/Thaumaturgy/essence.yml
@@ -287,3 +287,18 @@
         reagents:
         - ReagentId: CP14EssenceMagic
           Quantity: 1
+
+- type: entity
+  parent: CP14BaseEssence
+  id: CP14EssenceBeast
+  name: bestia
+  components:
+  - type: Sprite
+    color: "#5c3c0f"
+  - type: SolutionContainerManager
+    solutions:
+      essence:
+        maxVol: 1
+        reagents:
+        - ReagentId: CP14EssenceBeast
+          Quantity: 1

--- a/Resources/Prototypes/_CP14/MagicTypes/magic.yml
+++ b/Resources/Prototypes/_CP14/MagicTypes/magic.yml
@@ -99,3 +99,9 @@
   name: cp14-essence-magic
   color: "#5497d6"
   essenceProto: CP14EssenceMagic
+
+- type: magicType
+  id: Magic
+  name: cp14-essence-beast
+  color: "#5c3c0f"
+  essenceProto: CP14EssenceBeast

--- a/Resources/Prototypes/_CP14/Reagents/magic_essence.yml
+++ b/Resources/Prototypes/_CP14/Reagents/magic_essence.yml
@@ -217,3 +217,15 @@
   tileReactions:
   - !type:CreateEntityTileReaction
     entity: CP14EssenceMagic
+
+- type: reagent
+  parent: CP14EssenceBaseT2
+  id: CP14EssenceBeast
+  name: cp14-reagent-name-essence-beast
+  desc: cp14-reagent-desc-essence-beast
+  group: CP14MagicEssenceT2
+  color: "#5c3c0f"
+  pricePerUnit: 0.40  # craft (motion + life → 2)
+  tileReactions:
+  - !type:CreateEntityTileReaction
+    entity: CP14EssenceBeast

--- a/Resources/Prototypes/_CP14/Recipes/Reactions/Thaumaturgy/essence_combining.yml
+++ b/Resources/Prototypes/_CP14/Recipes/Reactions/Thaumaturgy/essence_combining.yml
@@ -142,3 +142,16 @@
   - !type:CP14AffectSolutionTemperature
     addTemperature: -150
 
+- type: reaction
+  id: CP14EssenceBeast
+  minTemp: 600
+  reactants:
+    CP14EssenceMotion:
+      amount: 1
+    CP14EssenceLife:
+      amount: 1
+  products:
+    CP14EssenceBeast: 2
+  effects:
+  - !type:CP14AffectSolutionTemperature
+    addTemperature: -150

--- a/Resources/Prototypes/_CP14/Recipes/Reactions/Thaumaturgy/target_effect_creation_on_water.yml
+++ b/Resources/Prototypes/_CP14/Recipes/Reactions/Thaumaturgy/target_effect_creation_on_water.yml
@@ -250,8 +250,43 @@
   - !type:CP14AffectSolutionTemperature
     addTemperature: -150
 
-# CP14BasicEffectSatiateHunger
-# CP14BasicEffectSatiateThirst
+- type: reaction
+  id: CP14WaterBrewingSatiateHunger
+  minTemp: 500
+  priority: 2
+  reactants:
+    CP14EssenceBeast:
+      amount: 2
+    CP14EssenceLife:
+      amount: 1
+    Water:
+      amount: 1
+  products:
+    CP14BasicEffectEmpty: 2
+    CP14BasicEffectEmoteCough: 1
+    CP14BasicEffectSatiateHunger: 1
+  effects:
+  - !type:CP14AffectSolutionTemperature
+    addTemperature: -150
+
+- type: reaction
+  id: CP14WaterBrewingSatiateThirst
+  minTemp: 500
+  priority: 1
+  reactants:
+    CP14EssenceWater:
+      amount: 1
+    CP14EssenceLife:
+      amount: 1
+    Water:
+      amount: 2
+  products:
+    CP14BasicEffectEmpty: 2
+    CP14BasicEffectRainbow: 1
+    CP14BasicEffectSatiateThirst: 1
+  effects:
+  - !type:CP14AffectSolutionTemperature
+    addTemperature: -150
 
 - type: reaction
   id: CP14WaterBrewingHealMana

--- a/Resources/ServerInfo/_CP14/Guidebook_EN/JobsTabs/AlchemistTabs/AlchemyTabs/Essence.xml
+++ b/Resources/ServerInfo/_CP14/Guidebook_EN/JobsTabs/AlchemistTabs/AlchemyTabs/Essence.xml
@@ -35,6 +35,7 @@ Minimal units of being. By obtaining them from splitting items and precursers, a
 ## Second Compound Essences:
 <Box>
 <GuideEntityEmbed Entity="CP14EssenceMagic"/>
+<GuideEntityEmbed Entity="CP14EssenceBeast"/>
 </Box>
 <GuideReagentGroupEmbed Group="CP14MagicEssenceT2"/>
 

--- a/Resources/ServerInfo/_CP14/Guidebook_RU/JobsTabs/AlchemistTabs/AlchemyTabs/Essence.xml
+++ b/Resources/ServerInfo/_CP14/Guidebook_RU/JobsTabs/AlchemistTabs/AlchemyTabs/Essence.xml
@@ -34,6 +34,7 @@
 ## Эссенции второго сложения:
 <Box>
 <GuideEntityEmbed Entity="CP14EssenceMagic"/>
+<GuideEntityEmbed Entity="CP14EssenceBeast"/>
 </Box>
 <GuideReagentGroupEmbed Group="CP14MagicEssenceT2"/>
 


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Added 1 new essence Bestia made with 1 motus and 1 victus. Also added recipes for Life giving moisture and Saturating solution, made with 1 aqua 1 victus 2 water and 2 bestia 1 victus 1 water respectively. Also fixed a minor grammatical error in the guidebook about lux.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
These 2 needed recipes and getting rather crowded on essences and none really fit for saturating's recipe.
## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->
![Screenshot 2025-07-02 184351](https://github.com/user-attachments/assets/09095ac8-aae5-4da4-ad30-cde23e1d8e40)
![Screenshot 2025-07-02 184342](https://github.com/user-attachments/assets/5f24df3b-ebaa-434a-8ee1-6754b35c251b)
![Screenshot 2025-07-02 184326](https://github.com/user-attachments/assets/2143c4c8-ec70-4d91-8f36-fb2ff97e39a7)

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: New essence Bestia a tier 2 essence.
- add: Saturating and life giving moisture solutions now have recipes that can be found in the guidebook.