### PR TITLE
Arrival notifications no longer mention the station

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -296,7 +296,7 @@ namespace Content.Server.GameTicking
                 else
                 {
                     _chatSystem.DispatchStationAnnouncement(station,
-                        Loc.GetString("latejoin-arrival-announcement",
+                        Loc.GetString("cp14-latejoin-arrival-announcement",//CrystallEdge
                             ("character", MetaData(mob).EntityName),
                             ("gender", character.Gender), // CrystallEdge-LastnameGender
                             ("entity", mob),

--- a/Resources/Locale/en-US/_CP14/game-tiker.ftl
+++ b/Resources/Locale/en-US/_CP14/game-tiker.ftl
@@ -1,0 +1,1 @@
+cp14-latejoin-arrival-announcement = {$character} ({$job}) has arrived in town!

--- a/Resources/Locale/ru-RU/_CP14/game-tiker.ftl
+++ b/Resources/Locale/ru-RU/_CP14/game-tiker.ftl
@@ -1,0 +1,7 @@
+cp14-latejoin-arrival-announcement =
+    { $character } ({ $job }) { $gender ->
+        [male] прибыл
+        [female] прибыла
+        [epicene] прибыли
+       *[neuter] прибыло
+    } в поселение!


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Arrival notifications no longer mention the station.

