### PR TITLE
Lightning strike nerf

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Electric/lightning_strike.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Electric/lightning_strike.yml
@@ -39,9 +39,9 @@
       sprite: _CP14/Actions/Spells/electromancy.rsi
       state: lightning_strike
   - type: TargetAction
-    canTargetSelf: false
     range: 5
   - type: EntityTargetAction
+    canTargetSelf: false
     event: !type:CP14DelayedEntityTargetActionEvent
       cooldown: 10
       castDelay: 2.0


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Lightning strike now has a limited radius and cannot be self-casted

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Lightning strike now has a limited radius and cannot be self-casted
