### PR TITLE
lightning strike nerf

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Electric/lightning_strike.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Electric/lightning_strike.yml
@@ -21,7 +21,7 @@
       - !type:HealthChange
         damage:
           types:
-            Shock: 20
+            Shock: 5
       - !type:Jitter
       - !type:CP14StaminaChange
         staminaDelta: -75
@@ -86,7 +86,7 @@
       - !type:HealthChange
         damage:
           types:
-            Shock: 10
+            Shock: 5
       - !type:Jitter
       - !type:CP14StaminaChange
         staminaDelta: -20

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Electric/lightning_strike_small.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Electric/lightning_strike_small.yml
@@ -18,10 +18,6 @@
       beamProto: CP14LightningStrikeSmallBeam
     - !type:CP14SpellApplyEntityEffect
       effects:
-      - !type:HealthChange
-        damage:
-          types:
-            Shock: 8
       - !type:Jitter
       - !type:CP14StaminaChange
         staminaDelta: -15
@@ -80,7 +76,7 @@
       - !type:HealthChange
         damage:
           types:
-            Shock: 7
+            Shock: 2
       - !type:Jitter
       - !type:CP14StaminaChange
         staminaDelta: -8


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Lightning Strike now deals 15 damage to the target instead of **40**
- 5 damage to the target itself
- 5 damage from lightning touch (triggered 2 times)
Small Lightning Strike now deals 4 damage instead of **18**
- 2 damage from lightning touch (triggered 2 times)

Удар молнии теперь наносит 15 урона по цели вместо **40**
- 5 по самой цели
- 5 от касания молнии (срабатывает 2 раза)
Малый удар молнии теперь наносит 4 урона вместо **18**и стоит меньше
- 2 от касания молнии (срабатывает 2 раза)
- стоимость уменьшена до 5

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
They deal a lot of damage, considering that they cast directly on the target, penetrate everyone in their path, and stun them.

Многовато у них урона учитывая что они кастуются прямо на цель, пробивают всех на пути, так ещё и станят

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Lightning strikes now deal less damage.
