### PR TITLE
Sharpening Stone fix

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Structures/Specific/Blacksmith/sharpening_stone.yml
+++ b/Resources/Prototypes/_CP14/Entities/Structures/Specific/Blacksmith/sharpening_stone.yml
@@ -14,6 +14,9 @@
     state: base
   - type: PlaceableSurface
   - type: ItemPlacer
+    whitelist:
+      components:
+        CP14Sharpened
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/_CP14/Entities/Structures/Specific/Blacksmith/sharpening_stone.yml
+++ b/Resources/Prototypes/_CP14/Entities/Structures/Specific/Blacksmith/sharpening_stone.yml
@@ -16,7 +16,7 @@
   - type: ItemPlacer
     whitelist:
       components:
-        CP14Sharpened
+        - CP14Sharpened
   - type: Fixtures
     fixtures:
       fix1:


### PR DESCRIPTION
## About the PR
added whitelist to sharpening stone

## Why / Balance
fix #1536 

**Changelog**
:cl:
fix: The blacksmith can no longer sharpen planks at the start of a round.
