### PR TITLE
Mercenary set in general loadout

### DIFF
--- a/Resources/Prototypes/_CP14/Loadouts/Jobs/general.yml
+++ b/Resources/Prototypes/_CP14/Loadouts/Jobs/general.yml
@@ -258,6 +258,7 @@
   - CP14ClothingHeadJagermeisterHat
   - CP14ClothingHeadStrawHat
   - CP14ClothingHeadKasaHat
+  - CP14ClothingHeadBeretMercenary
 
 - type: loadout
   id: CP14ClothingHeadMetalHeadband
@@ -309,6 +310,10 @@
   equipment:
     head: CP14ClothingHeadKasaHat
 
+- type: loadout
+  id: CP14ClothingHeadBeretMercenary
+  equipment:
+    head: CP14ClothingHeadBeretMercenary
 
 # Pants
 
@@ -324,6 +329,7 @@
   - CP14ClothingPantsGreen
   - CP14ClothingPantsBrown
   - CP14ClothingPantsHakama
+  - CP14ClothingPantsMercenaryTrousers
 
 - type: loadout
   id: CP14ClothingPantsTrouserWhite
@@ -364,6 +370,11 @@
   id: CP14ClothingPantsHakama
   equipment:
     pants: CP14ClothingPantsHakama
+
+- type: loadout
+  id: CP14ClothingPantsMercenaryTrousers
+  equipment:
+    pants: CP14ClothingPantsMercenaryTrousers
 
 # Shirt
 
@@ -411,6 +422,7 @@
   - CP14ClothingCottonYellowCollarDress
   - CP14ClothinShirtYellowBlueDress
   - CP14ClothingWarriorsGarbDress
+  - CP14ClothingShirtMercenary
 
 - type: loadout
   id: CP14ClothingShirtCottonBlack
@@ -611,6 +623,11 @@
   id: CP14ClothinShirtWhiteBrown
   equipment:
     shirt: CP14ClothinShirtWhiteBrown
+
+- type: loadout
+  id: CP14ClothingShirtMercenary
+  equipment:
+    shirt: CP14ClothingShirtMercenary
 
 # Shoes
 


### PR DESCRIPTION
## About the PR
Adds mercenary beret, mercenary shirt and mercenary pants into the general loadout group.
<!-- What did you change in this PR? -->

## Why / Balance
Easy but pain in the ass to craft during a round and it's so drippy. Adventurer is called a "mercenary job" in the menu so why shouldn't we have the mercenary set :)
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: cooldolphin
- add: The mercenary outfit is now available for equipping in the loadout menu.

