### PR TITLE
Bugfixes

### DIFF
--- a/Content.Server/_CP14/LockKey/CP14KeyholeGenerationSystem.cs
+++ b/Content.Server/_CP14/LockKey/CP14KeyholeGenerationSystem.cs
@@ -57,7 +57,7 @@ public sealed partial class CP14KeyholeGenerationSystem : EntitySystem
     private List<int> GetKeyLockData(ProtoId<CP14LockTypePrototype> category)
     {
         if (_roundKeyData.ContainsKey(category))
-            return _roundKeyData[category];
+            return new List<int>(_roundKeyData[category]);
 
         var newData = GenerateNewUniqueLockData(category);
         _roundKeyData[category] = newData;

--- a/Resources/Prototypes/_CP14/Alerts/status_effect.yml
+++ b/Resources/Prototypes/_CP14/Alerts/status_effect.yml
@@ -1,10 +1,4 @@
 - type: alert
-  id: CP14Glowing
-  icons:
-  - sprite: _CP14/Actions/Spells/light.rsi
-    state: sphere_of_light
-
-- type: alert
   id: CP14MagicArmor
   icons:
   - sprite: _CP14/Actions/Spells/meta.rsi

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Light/sphere_of_light.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Light/sphere_of_light.yml
@@ -15,9 +15,9 @@
     - !type:CP14SpellSpawnEntityOnTarget
       spawns:
       - CP14ImpactEffectSphereOfLight
-    - !type:CP14SpellApplyStatusEffect
-      statusEffect: CP14StatusEffectGlowing
-      duration: 120
+    - !type:CP14SpellSpawnInHandEntity
+      spawns:
+      - CP14SphereOfLight
   - type: CP14MagicEffectVerbalAspect
     startSpeech: "Appare in manu tua..."
     endSpeech: "sphaera lucis"
@@ -28,15 +28,8 @@
     icon:
       sprite: _CP14/Actions/Spells/light.rsi
       state: sphere_of_light
-  - type: TargetAction
-    range: 5
-  - type: EntityTargetAction
-    whitelist:
-      components:
-      - MobState
-      - Item
-      - Anchorable
-    event: !type:CP14DelayedEntityTargetActionEvent
+  - type: InstantAction
+    event: !type:CP14DelayedInstantActionEvent
       cooldown: 30
       castDelay: 0.5
       breakOnMove: false
@@ -75,3 +68,40 @@
   - type: CP14SpellStorage
     spells:
     - CP14ActionSpellSphereOfLight
+
+- type: entity
+  id: CP14SphereOfLight
+  name: Sphere of light
+  parent: BaseItem
+  description: A lump of bright light in the shape of a sphere.
+  categories: [ ForkFiltered ]
+  components:
+  - type: TimedDespawn
+    lifetime: 120 # 2 min
+  - type: Sprite
+    sprite: _CP14/Effects/Magic/sphere_of_light.rsi
+    noRot: true
+    layers:
+    - state: icon
+      shader: unshaded
+  - type: Item
+    size: Ginormous
+    inhandVisuals:
+      left:
+      - state: inhand-left-unshaded
+        shader: unshaded
+      right:
+      - state: inhand-right-unshaded
+        shader: unshaded
+  - type: LandAtCursor
+  - type: MovementIgnoreGravity
+  - type: PointLight
+    radius: 5.0
+    energy: 1
+    color: "#efedff"
+  - type: Damageable
+  - type: EmitSoundOnLand
+    sound:
+      path: /Audio/Effects/drop.ogg
+      params:
+        volume: -100 #Yes, it's stupid, but it's easier

--- a/Resources/Prototypes/_CP14/Entities/StatusEffects/misc.yml
+++ b/Resources/Prototypes/_CP14/Entities/StatusEffects/misc.yml
@@ -1,23 +1,4 @@
 - type: entity
-  id: CP14StatusEffectGlowing
-  components:
-  - type: StatusEffect
-  - type: StatusEffectAlert
-    alert: CP14Glowing
-  - type: Sprite
-    drawdepth: Effects
-    sprite: _CP14/Effects/Magic/sphere_of_light.rsi
-    offset: 0, 1
-    noRot: true
-    layers:
-    - state: icon
-      shader: unshaded
-  - type: PointLight
-    radius: 5.0
-    energy: 1
-    color: "#efedff"
-
-- type: entity
   id: CP14StatusEffectMagicArmor
   components:
   - type: StatusEffect

--- a/Resources/Prototypes/_CP14/Entities/Structures/Roof/base.yml
+++ b/Resources/Prototypes/_CP14/Entities/Structures/Roof/base.yml
@@ -27,6 +27,8 @@
     base: roof
   - type: IsRoof
   - type: SunShadowCast
+  - type: WallMount
+    arc: 360
 
 - type: entity
   parent:


### PR DESCRIPTION
fix #1593 
fix #1236
fix #1561

:cl:
- tweak: The sphere of light now returns the item to your hand instead of applying a status effect. Bug fix, as the sphere of light had completely stopped glowing.
- fix: Roofs can now be deconstructed above walls.
- fix: Fixed a bug with changing the shape of the key, which changed all subsequent doors and keys.