### PR TITLE
Backpacks tweaks

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/_CP14/Entities/Clothing/Back/backpacks.yml
@@ -171,8 +171,8 @@
         Piercing: 0.95
         Heat: 0.92
   - type: ClothingSpeedModifier
-    walkModifier: 0.80
-    sprintModifier: 0.80
+    walkModifier: 0.82
+    sprintModifier: 0.82
 
 - type: entity
   parent: CP14ClothingBackBackpackT2
@@ -197,5 +197,5 @@
       CP14Iron: 12 # 12u CP14IronBuckle (6x2u)
       # Cost: (96×1.2) + (96×0.4) + (12×2) = 115.2 + 38.4 + 24 = 177.6 copper coins
   - type: ClothingSpeedModifier
-    walkModifier: 0.83
-    sprintModifier: 0.83
+    walkModifier: 0.84
+    sprintModifier: 0.84

--- a/Resources/Prototypes/_CP14/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/_CP14/Entities/Clothing/Back/backpacks.yml
@@ -98,8 +98,8 @@
         Heat: 0.90
         Caustic: 0.90
   - type: ClothingSpeedModifier
-    walkModifier: 0.85
-    sprintModifier: 0.85
+    walkModifier: 0.80
+    sprintModifier: 0.80
 
 - type: entity
   parent: CP14ClothingBackBackpackT2

--- a/Resources/Prototypes/_CP14/Entities/Clothing/Back/backpacks_satchels.yml
+++ b/Resources/Prototypes/_CP14/Entities/Clothing/Back/backpacks_satchels.yml
@@ -114,7 +114,7 @@
         Heat: 0.98
         Caustic: 0.96
   - type: ClothingSpeedModifier
-    sprintModifier: 0.80
+    sprintModifier: 0.85
 
 - type: entity
   parent: CP14ClothingBackSatchelBase
@@ -186,4 +186,4 @@
         Piercing: 0.97
         Heat: 0.98
   - type: ClothingSpeedModifier
-    sprintModifier: 0.77
+    sprintModifier: 0.88

--- a/Resources/Prototypes/_CP14/Entities/Clothing/Belt/pouch.yml
+++ b/Resources/Prototypes/_CP14/Entities/Clothing/Belt/pouch.yml
@@ -31,3 +31,9 @@
   - type: StorageContainerVisuals
     maxFillLevels: 2
     fillBaseName: fill-
+  - type: PhysicalComposition
+    materialComposition:
+      CP14Leather: 19 # 10u CP14Leather (1x10u) + 9u CP14LeatherStrap (3x3u)
+      CP14SaltStone: 19 # 10u (1x10u) + 9u (3x3u)
+      CP14Cloth: 20 # 20u CP14String (4x5u)
+      # Cost: (19×1.2) + (19×0.4) + (20×0.3) = 22.8 + 7.6 + 6 = 36.4 copper coins

--- a/Resources/Prototypes/_CP14/Entities/Clothing/Belt/quiver.yml
+++ b/Resources/Prototypes/_CP14/Entities/Clothing/Belt/quiver.yml
@@ -31,6 +31,12 @@
   - type: StorageContainerVisuals
     maxFillLevels: 3
     fillBaseName: fill-
+  - type: PhysicalComposition
+    materialComposition:
+      CP14Leather: 36 # 30u CP14Leather (3x10u) + 6u CP14LeatherStrap (2x3u)
+      CP14SaltStone: 36 # 30u (3x10u) + 6u (2x3u)
+      CP14Cloth: 20 # 20u CP14String (4x5u)
+      # Cost: (36×1.2) + (36×0.4) + (20×0.3) = 43.2 + 14.4 + 6 = 63.6 copper coins
 
 - type: entity
   parent: CP14ClothingBeltQuiver

--- a/Resources/Prototypes/_CP14/Entities/Mobs/NPC/animals.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/NPC/animals.yml
@@ -522,8 +522,17 @@
   - type: CP14MagicCasterSlowdown
   - type: Butcherable
     spawned:
-    - id: CP14FoodMeatPig # TODO 
+    - id: CP14FoodMeatBoar # TODO
       amount: 5
+    - id: CP14RuggedAnimalHide
+      amount: 2
+      maxAmount: 5
+    - id: CP14ScrapAnimalHide
+      amount: 2
+      maxAmount: 6
+      prob: 0.5
+    - id: CP14GoodFur
+      amount: 1
   - type: Bloodstream
     bloodMaxVolume: 350
     bloodReagent: CP14BloodAnimal

--- a/Resources/Prototypes/_CP14/Recipes/Workbench/LeatherWorking/tanner.yml
+++ b/Resources/Prototypes/_CP14/Recipes/Workbench/LeatherWorking/tanner.yml
@@ -141,3 +141,42 @@
   result: CP14RuggedStrap
   resultCount: 4 # 4x straps (6u leather + 5u salt total, 1.5u + 1.25u each)
   # Cost: (25×1.2) + (20×0.4) + (15×0.3) = 30 + 8 + 4.5 = 42.5 copper coins
+
+
+# ================
+# Leather belts crafting
+
+- type: CP14Recipe
+  id: CP14LeatherStrapRecipe
+  tag: CP14RecipeLeatherWorking
+  craftTime: 1
+  requirements:
+  - !type:ProtoIdResource
+    protoId: CP14Leather
+    count: 3 # 30u leather + 30u salt
+  - !type:ProtoIdResource
+    protoId: CP14LeatherStrap
+    count: 2 # 6u leather + 6u salt
+  - !type:ProtoIdResource
+    protoId: CP14String
+    count: 4 # 20u cloth
+  result: CP14ClothingBeltQuiver
+  # Cost: (36×1.2) + (36×0.4) + (20×0.3) = 43.2 + 14.4 + 6 = 63.6 copper coins
+
+- type: CP14Recipe
+  id: CP14LeatherStrapRecipe
+  tag: CP14RecipeLeatherWorking
+  craftTime: 1
+  requirements:
+  - !type:ProtoIdResource
+    protoId: CP14Leather
+    count: 1 # 10u leather + 10u salt
+  - !type:ProtoIdResource
+    protoId: CP14LeatherStrap
+    count: 3 # 9u leather + 9u salt
+  - !type:ProtoIdResource
+    protoId: CP14String
+    count: 4 # 20u cloth
+  result: CP14ClothingBeltQuiver
+  # Cost: (19×1.2) + (19×0.4) + (20×0.3) = 22.8 + 7.6 + 6 = 36.4 copper coins
+CP14ClothingBeltPouchPotions

--- a/Resources/Prototypes/_CP14/Recipes/Workbench/LeatherWorking/tanner.yml
+++ b/Resources/Prototypes/_CP14/Recipes/Workbench/LeatherWorking/tanner.yml
@@ -147,7 +147,7 @@
 # Leather belts crafting
 
 - type: CP14Recipe
-  id: CP14LeatherStrapRecipe
+  id: CP14ClothingBeltQuiverRecipe
   tag: CP14RecipeLeatherWorking
   craftTime: 1
   requirements:
@@ -164,7 +164,7 @@
   # Cost: (36×1.2) + (36×0.4) + (20×0.3) = 43.2 + 14.4 + 6 = 63.6 copper coins
 
 - type: CP14Recipe
-  id: CP14LeatherStrapRecipe
+  id: CP14ClothingBeltPouchPotionsRecipe
   tag: CP14RecipeLeatherWorking
   craftTime: 1
   requirements:
@@ -177,6 +177,5 @@
   - !type:ProtoIdResource
     protoId: CP14String
     count: 4 # 20u cloth
-  result: CP14ClothingBeltQuiver
+  result: CP14ClothingBeltPouchPotions
   # Cost: (19×1.2) + (19×0.4) + (20×0.3) = 22.8 + 7.6 + 6 = 36.4 copper coins
-CP14ClothingBeltPouchPotions


### PR DESCRIPTION
## About the PR
Добавляем медведю дроп шкуры.
Правим скорость между сатчелями и рюкзачками.
Добавляем крафт колчана и алхимического пояса

## Why / Balance
Всё должно быть хорошо. Понемногу вводим кожу в экономику.
Пока нету траты стамины - будут затраты в скорости.

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->

<img width="462" height="550" alt="image" src="https://github.com/user-attachments/assets/12c31573-31e5-49f4-b150-8d6f1573a6a3" />


**Changelog**

:cl:
- add: Adding a bear skin drop.
- add: Adding quiver and alchemy belt crafting
- tweak: Adjusting the speed between satchels and backpacks.

