### PR TITLE
fix generation dublication

### DIFF
--- a/Content.Server/_CP14/Procedural/GenerationLayers/CP14Biome.cs
+++ b/Content.Server/_CP14/Procedural/GenerationLayers/CP14Biome.cs
@@ -23,6 +23,7 @@ public sealed partial class DungeonJob
         if (!_prototype.TryIndex(dunGen.BiomeTemplate, out var indexedBiome))
             return;
 
+        HashSet<Vector2i> processedTiles = new();
         var biomeSystem = _entManager.System<BiomeSystem>();
 
         var seed = random.Next();
@@ -32,6 +33,11 @@ public sealed partial class DungeonJob
         {
             foreach (var node in dun.AllTiles)
             {
+                if (processedTiles.Contains(node))
+                    continue;
+
+                processedTiles.Add(node);
+
                 var tileRef = _maps.GetTileRef(_gridUid, _grid, node);
 
                 if (reservedTiles.Contains(node))

--- a/Content.Server/_CP14/Procedural/GenerationLayers/CP14Ore.cs
+++ b/Content.Server/_CP14/Procedural/GenerationLayers/CP14Ore.cs
@@ -20,6 +20,7 @@ public sealed partial class DungeonJob
         HashSet<Vector2i> reservedTiles,
         Random random)
     {
+        HashSet<Vector2i> processedTiles = new();
         var replaceEntities = new Dictionary<Vector2i, EntityUid>();
         var availableTiles = new List<Vector2i>();
 
@@ -27,6 +28,11 @@ public sealed partial class DungeonJob
         {
             foreach (var tile in dun.AllTiles)
             {
+                if (processedTiles.Contains(tile))
+                    continue;
+
+                processedTiles.Add(tile);
+
                 var tileRef = _maps.GetTileRef(_gridUid, _grid, tile);
 
                 //Tile mask filtering

--- a/Content.Server/_CP14/Procedural/GenerationLayers/CP14Rooms.cs
+++ b/Content.Server/_CP14/Procedural/GenerationLayers/CP14Rooms.cs
@@ -17,6 +17,7 @@ public sealed partial class DungeonJob
         HashSet<Vector2i> reservedTiles,
         Random random)
     {
+        HashSet<Vector2i> processedTiles = new();
         List<DungeonRoomPrototype> availableRooms = new();
         var availableTiles = new List<Vector2i>();
 
@@ -39,6 +40,11 @@ public sealed partial class DungeonJob
         {
             foreach (var tile in dun.AllTiles)
             {
+                if (processedTiles.Contains(tile))
+                    continue;
+
+                processedTiles.Add(tile);
+
                 var tileRef = _maps.GetTileRef(_gridUid, _grid, tile);
 
                 if (reservedTiles.Contains(tile))


### PR DESCRIPTION
:cl:
- fix: Fixed a bug where entities were duplicated during generation, which prevented digging ores in mines and chopping down trees.
