### PR TITLE
Soup bugfix and price change

### DIFF
--- a/Content.Shared/_CP14/Cooking/CP14SharedCookingSystem.cs
+++ b/Content.Shared/_CP14/Cooking/CP14SharedCookingSystem.cs
@@ -281,14 +281,14 @@ public abstract partial class CP14SharedCookingSystem : EntitySystem
 
         var newData = new CP14FoodData(recipe.FoodData);
 
+        //Assign recipe to the FoodData
+        newData.CurrentRecipe = recipe.ID;
+
         //Process entities
         foreach (var contained in container.ContainedEntities)
         {
             if (TryComp<FoodComponent>(contained, out var food))
             {
-                //Assign recipe to the FoodData
-                newData.CurrentRecipe = recipe.ID;
-
                 //Merge trash
                 newData.Trash.AddRange(food.Trash);
 

--- a/Content.Shared/_CP14/Cooking/CP14SharedCookingSystem.cs
+++ b/Content.Shared/_CP14/Cooking/CP14SharedCookingSystem.cs
@@ -286,6 +286,9 @@ public abstract partial class CP14SharedCookingSystem : EntitySystem
         {
             if (TryComp<FoodComponent>(contained, out var food))
             {
+                //Assign recipe to the FoodData
+                newData.CurrentRecipe = recipe.ID;
+
                 //Merge trash
                 newData.Trash.AddRange(food.Trash);
 

--- a/Content.Shared/_CP14/Workbench/Requirements/FoodResource.cs
+++ b/Content.Shared/_CP14/Workbench/Requirements/FoodResource.cs
@@ -87,7 +87,7 @@ public sealed partial class FoodResource : CP14WorkbenchCraftRequirement
 
         var complexity = indexedRecipe.Requirements.Sum(req => req.GetComplexity());
 
-        return complexity * 10;
+        return complexity * 6;
     }
 
     public override string GetRequirementTitle(IPrototypeManager protoManager)


### PR DESCRIPTION
## About the PR
Подправлены цены при продаже супов на контрактах. Теперь за них не платят настолько много.
Теперь супы продаваемы по контрактам

## Why / Balance
fix #1620. 

:cl:
- fix: Now soups can be sold when completing contracts
- tweak: Now soups sell less when completing contracts
