### PR TITLE
Spell rebalance

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/firewave.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/firewave.yml
@@ -87,7 +87,7 @@
     impactEffect: CP14ImpactEffectFirebolt
     damage:
       types:
-        Heat: 3
+        Heat: 2
     soundHit:
       path: /Audio/Weapons/Guns/Hits/energy_metal1.ogg
   - type: Sprite

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/ice_arrow.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/ice_arrow.yml
@@ -30,7 +30,8 @@
       state: ice_arrow
   - type: InstantAction
     event: !type:CP14DelayedInstantActionEvent
-      cooldown: 10
+      cooldown: 5
+      castDelay: 0.5
       breakOnMove: false
 
 - type: entity

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/ice_dagger.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/ice_dagger.yml
@@ -30,7 +30,8 @@
       state: ice_dagger
   - type: InstantAction
     event: !type:CP14DelayedInstantActionEvent
-      cooldown: 10
+      cooldown: 5
+      castDelay: 0.5
       breakOnMove: false
 
 - type: entity
@@ -119,13 +120,13 @@
   - type: CP14MeleeSelfDamage
     damageToSelf:
       types:
-        Blunt: 1 # 10 hits
+        Blunt: 1 # 20 hits
   - type: Damageable
   - type: Destructible
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 10
+        damage: 20
       behaviors:
       - !type:PlaySoundBehavior
         sound:

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/ice_shards.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/ice_shards.yml
@@ -64,7 +64,7 @@
   - type: Projectile
     damage:
       types:
-        Cold: 4
+        Cold: 6
         Piercing: 2
   - type: Sprite
     sprite: _CP14/Effects/Magic/ice_shard.rsi


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
nerfed fire wave down to 2 damage (i think that was a previous value), ice arrow and ice dagger both have 5 second cooldown and cast times of 0.5 seconds ice dagger also has double the durability, ice shard now deals 6 cold (previously 4) and still has 2 pierce
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
firewave was too strong honestly took me too long to realize it and the other spells ive never seen used. outside of forced uses like raid skele ice shard

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
-->
:cl:
- tweak: Changed ice dagger now has its cooldown halved (5s now) and a cast time of 0.5 seconds, along with having 20 hits till breaking (4 for throwing).
- tweak: Changed ice arrow now has its cooldown halved (5s now) and a cast time of 0.5 seconds.
- tweak: Changed ice shard now does 6 cold and 2 pierce damage from 4 and 2.
- tweak: Changed fire wave now does 2 heat damage per projectile from 3.
