### PR TITLE
Fix mosquitos stamina animation threshold

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Mobs/NPC/mosquito.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/NPC/mosquito.yml
@@ -41,6 +41,7 @@
   - type: Appearance
   - type: Stamina
     critThreshold: 50
+    animationThreshold: 9999 # They don't need jitter animation
   - type: DamageContacts
     damage:
       types:


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Because mosquitos stamina crit threshold was set to `50` (unlucky choosen), it's same as jitter animation playing treshold that also 50, and that trigger debug assertation warning but in prod can cause probably bigger problems.
So I just changed animation playing treshold to big value, because I not sure if for mosquitos okay to jitter in stamina crit?

Fix #1633
Fix #1598

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->
https://github.com/user-attachments/assets/a456992c-2288-46bd-953e-2a5ac9e76c7c

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed mosquitos killing problems
