### PR TITLE
Bugfix portion

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -201,7 +201,7 @@
   abstract: true
   components:
   - type: Flammable
-    fireSpread: false #CP14 false
+    fireSpread: true
     canResistFire: true
     damage: #per second, scales with number of fire 'stacks'
       types:

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Athletic/kick.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Athletic/kick.yml
@@ -25,6 +25,7 @@
     - !type:CP14SpellApplyEntityEffect
       effects:
       - !type:HealthChange
+        ignoreResistances: false
         damage:
           types:
             Blunt: 5

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Athletic/sprint.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Athletic/sprint.yml
@@ -10,7 +10,7 @@
   - type: CP14MagicEffectCastSlowdown
     speedMultiplier: 1.3
   - type: CP14MagicEffectStaminaCost
-    stamina: 3
+    stamina: 1.5
   - type: CP14MagicEffect
     effects:
     - !type:CP14SpellSpawnEntityOnTarget
@@ -24,5 +24,5 @@
     event: !type:CP14ToggleableInstantActionEvent
       effectFrequency: 0.2
       cooldown: 2
-      castTime: 10
+      castTime: 30
       hidden: true

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Demigods/Lumera/moon_strike.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Demigods/Lumera/moon_strike.yml
@@ -80,6 +80,7 @@
       effects:
       - !type:Jitter
       - !type:HealthChange
+        ignoreResistances: false
         damage:
           types:
             Heat: 10

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Electric/lightning_strike.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Electric/lightning_strike.yml
@@ -19,6 +19,7 @@
     - !type:CP14SpellApplyEntityEffect
       effects:
       - !type:HealthChange
+        ignoreResistances: false
         damage:
           types:
             Shock: 5
@@ -84,6 +85,7 @@
     - !type:CP14SpellApplyEntityEffect
       effects:
       - !type:HealthChange
+        ignoreResistances: false
         damage:
           types:
             Shock: 5

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Electric/lightning_strike_small.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Electric/lightning_strike_small.yml
@@ -74,6 +74,7 @@
     - !type:CP14SpellApplyEntityEffect
       effects:
       - !type:HealthChange
+        ignoreResistances: false
         damage:
           types:
             Shock: 2

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Lurker/Kick.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Lurker/Kick.yml
@@ -29,9 +29,10 @@
     - !type:CP14SpellApplyEntityEffect
       effects:
       - !type:HealthChange
+        ignoreResistances: false
         damage:
           types:
-            Blunt: 5
+            Blunt: 10
   - type: CP14MagicEffectEmoting
     startEmote: cp14-kick-lurker-start
     endEmote: cp14-kick-lurker

--- a/Resources/Prototypes/_CP14/Entities/fire.yml
+++ b/Resources/Prototypes/_CP14/Entities/fire.yml
@@ -104,7 +104,7 @@
       Flammable: [ Touch ]
       Extinguish: [ Touch ]
   - type: Flammable
-    fireSpread: true
+    fireSpread: false
     canResistFire: false
     alwaysCombustible: true
     canExtinguish: true
@@ -132,4 +132,6 @@
   - type: CP14FireSpread
     spreadCooldownMin: 1
     spreadCooldownMax: 3
+  - type: Flammable
+    fireSpread: true
 


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
fix #1634
fix #1575
fix #1612

:cl:
- tweak: Sprint buffs: Stamina consumption reduced by half. The less stamina you have, the slower you move, which is still the case, but sprinting is now useful again.
- fix: The web now ignites players upon contact if it is burning.
- fix: Spells that deal direct damage (kicks, lightning strikes, Lumera beams) now take into account the target's damage resistances.

