### PR TITLE
Make IsDayNow method and return silva photosynthesis

### DIFF
--- a/Content.Shared/_CP14/DayCycle/CP14DayCycleSystem.cs
+++ b/Content.Shared/_CP14/DayCycle/CP14DayCycleSystem.cs
@@ -87,6 +87,12 @@ public sealed class CP14DayCycleSystem : EntitySystem
         return (float)lightLevel;
     }
 
+    public bool IsDayNow(Entity<LightCycleComponent?> map)
+    {
+        var lightLevel = GetLightLevel(map);
+        return lightLevel >= 0.5;
+    }
+
     /// <summary>
     /// Checks to see if the specified entity is on the map where it's daytime.
     /// </summary>
@@ -101,7 +107,7 @@ public sealed class CP14DayCycleSystem : EntitySystem
         if (xform.MapUid is null || xform.GridUid is null)
             return false;
 
-        var day = GetLightLevel(xform.MapUid.Value) > 0.5f;
+        var day = IsDayNow(xform.MapUid.Value);
 
         var grid = xform.GridUid;
         if (grid is null)

--- a/Content.Shared/_CP14/Random/Rules/IsDaylight.cs
+++ b/Content.Shared/_CP14/Random/Rules/IsDaylight.cs
@@ -18,8 +18,8 @@ public sealed partial class CP14IsNight : RulesRule
         if (map is null)
             return false;
 
-        var lightLevel = dayCycle.GetLightLevel(map.Value);
+        var isDay = dayCycle.IsDayNow(map.Value);
 
-        return Inverted ? lightLevel < 0.5 : lightLevel >= 0.5;
+        return Inverted ? !isDay : isDay;
     }
 }

--- a/Resources/Prototypes/_CP14/Entities/Mobs/Species/silva.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/Species/silva.yml
@@ -66,9 +66,7 @@
     freeLearnedSkills:
     - HealingT1
     - HealingT2
-  - type: CP14MagicEnergyPhotosynthesis # Silva special feature #Disabled until sunlight fixed
-  - type: CP14MagicEnergyDraw #Enabled default mana regen until sunlight fixed
-    enable: false
+  - type: CP14MagicEnergyPhotosynthesis # Silva special feature
   - type: Body
     prototype: CP14Silva
     requiredLegs: 2


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
I'm failed to localy reproduce problem. My only trought that 0.5 day light is really alredy looks like a night.
So if issues was created no by checking light level and only of "feel of day" then probably all worked correctly.

I made more clear method to check a IsDayNow.
And fixed `IsDaylight` rule for ambient that was inverted.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.-->

:cl:
- fix: Silvas now back to photosynthesis only mana regeneration
