### PR TITLE
no more magic type mana armor

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Meta/mana_armor.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Meta/mana_armor.yml
@@ -11,7 +11,6 @@
   - type: CP14MagicEffectCastingVisual
     proto: CP14RuneManaTrance
   - type: CP14MagicEffect
-    magicType: Fire
     effects:
     - !type:CP14SpellSpawnEntityOnTarget
       spawns:


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
deleted the magic type from magic armor
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
no other metamagic spells have a magic type

