### PR TITLE
Villagers and lumera trade vision

### DIFF
--- a/Resources/Prototypes/_CP14/Roles/Jobs/Artisan/alchemist.yml
+++ b/Resources/Prototypes/_CP14/Roles/Jobs/Artisan/alchemist.yml
@@ -7,9 +7,17 @@
   icon: "CP14JobIconAlchemist"
   supervisors: cp14-job-supervisors-command
   special:
+    - !type:CP14AddTradingReputationSpecial
+      factions:
+      - VictoriaGardens
+      - BradPotions
+      - Thaumaturgy
+      - HomeDecor
+      - Horticulture
     - !type:CP14LearnSkillsSpecial
       skills:
       - AlchemyVision
+      - TraderWit
   requirements:
     - !type:DepartmentTimeRequirement
       department: CP14Artisan

--- a/Resources/Prototypes/_CP14/Roles/Jobs/Artisan/blacksmith.yml
+++ b/Resources/Prototypes/_CP14/Roles/Jobs/Artisan/blacksmith.yml
@@ -7,6 +7,13 @@
   icon: "CP14JobIconBlacksmith"
   supervisors: cp14-job-supervisors-command
   special:
+    - !type:CP14AddTradingReputationSpecial
+      factions:
+      - DwarfMining
+      - Thaumaturgy
+      - HomeDecor
+      - Butchers # For leather
+      - Tailors
     - !type:CP14LearnSkillsSpecial
       skills:
       - CopperMelting
@@ -14,6 +21,7 @@
       - GoldMelting
       - GlassMelting
       - MithrilMelting
+      - TraderWit
   requirements:
     - !type:DepartmentTimeRequirement
       department: CP14Artisan

--- a/Resources/Prototypes/_CP14/Roles/Jobs/Artisan/innkeeper.yml
+++ b/Resources/Prototypes/_CP14/Roles/Jobs/Artisan/innkeeper.yml
@@ -6,6 +6,16 @@
   startingGear: CP14InnkeeperGear
   icon: "CP14JobIconInnkeeper"
   supervisors: cp14-job-supervisors-command
+  special:
+    - !type:CP14AddTradingReputationSpecial
+      factions:
+      - VictoriaGardens
+      - HomeDecor
+      - Butchers
+      - Dairy
+    - !type:CP14LearnSkillsSpecial
+      skills:
+      - TraderWit
 
 - type: startingGear
   id: CP14InnkeeperGear

--- a/Resources/Prototypes/_CP14/Roles/Jobs/Demigods/lumera.yml
+++ b/Resources/Prototypes/_CP14/Roles/Jobs/Demigods/lumera.yml
@@ -14,3 +14,8 @@
   requireAdminNotify: true
   jobPreviewEntity: CP14MobGodLumera
   applyTraits: false
+  special:
+    - !type:CP14LearnSkillsSpecial
+      skills:
+      - TraderWit # Lumera is the goddess of knowledge, which means she knows what prices are!
+      - AlchemyVision


### PR DESCRIPTION
## About the PR
Выдаем поселенцам и Люмере видение торговца раундстартом.
Также поселенцы получают "связи в контрактах" с торговыми гильдиями, которые им необходимы.

Торговое видение и контракты получают:
- Трактирщик - к садам, мясникам, молочке
- Кузнец - к дварфам, тауматургам, портным, мясникам (для кожи)
- Алхимик - к тауматургам, цветочкам, зельям
Дополнительно все получают HomeDecor (все-таки они все владельцы домов и "откуда-то" мебель-то достали. 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Все селяне напрямую работают с деньгами и знают что такое торговля. Странно что им постоянно раундстартом нужно брать этот базовый скилл. 
Ну а Люмера богиня знаний, она явно должна знать в том числе сколько что стоит и сколько в этом реагентов.

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.

:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- add: Added Trade Vision and Contracts for villagers
- add: Added Trade Vision and AlchemyVision for Lumera
