### PR TITLE
More spell balance

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Electric/speed_ballade.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Electric/speed_ballade.yml
@@ -41,6 +41,7 @@
       cooldown: 15
       castTime: 120
       hidden: true
+      breakOnDamage: false
 
 - type: entity
   id: CP14ImpactEffectSpeedBallade

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/firewave.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/firewave.yml
@@ -33,8 +33,11 @@
     checkCanAccess: false
     range: 60
   - type: WorldTargetAction
-    event: !type:CP14WorldTargetActionEvent
+    event: !type:CP14DelayedWorldTargetActionEvent
       cooldown: 1.0
+      castDelay: 0.5
+      breakOnMove: false
+      breakOnDamage: false
 
 - type: entity
   id: CP14RuneFirebolt
@@ -95,8 +98,7 @@
     layers:
     - state: small
       shader: unshaded
-  - type: ChangeTemperatureOnCollide
-    heat: 10000
+
 
 - type: entity
   parent: CP14BaseSpellScrollFire

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/heat.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/heat.yml
@@ -28,6 +28,7 @@
     startSpeech: "Vos adepto calidum..."
   - type: CP14MagicEffectCastingVisual
     proto: CP14RuneHeat
+  - type: CP14MagicEffectPacifiedBlock
   - type: Action
     icon:
       sprite: _CP14/Actions/Spells/fire.rsi

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/hell_ballade.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/hell_ballade.yml
@@ -45,6 +45,7 @@
       cooldown: 15
       castTime: 120
       hidden: true
+      breakOnDamage: false
 
 - type: entity
   id: CP14ImpactEffectHellBallade

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/hell_ballade.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/hell_ballade.yml
@@ -35,6 +35,7 @@
   - type: CP14MagicEffectRequiredMusicTool
   - type: CP14MagicEffectCastingVisual
     proto: CP14RuneHellBallade
+  - type: CP14MagicEffectPacifiedBlock
   - type: Action
     icon:
       sprite: _CP14/Actions/Spells/fire.rsi

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/hell_ballade.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/hell_ballade.yml
@@ -8,9 +8,9 @@
     sprite: _CP14/Actions/Spells/fire.rsi
     state: fire_music
   - type: CP14MagicEffectCastSlowdown
-    speedMultiplier: 0.8
+    speedMultiplier: 0.7
   - type: CP14MagicEffectManaCost
-    manaCost: 1
+    manaCost: 8
   - type: CP14MagicEffect
     magicType: Fire
     effects:

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/hell_ballade.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/hell_ballade.yml
@@ -8,7 +8,7 @@
     sprite: _CP14/Actions/Spells/fire.rsi
     state: fire_music
   - type: CP14MagicEffectCastSlowdown
-    speedMultiplier: 0.7
+    speedMultiplier: 0.5
   - type: CP14MagicEffectManaCost
     manaCost: 8
   - type: CP14MagicEffect

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Meta/mana_ballade.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Meta/mana_ballade.yml
@@ -43,6 +43,7 @@
       cooldown: 15
       castTime: 120
       hidden: true
+      breakOnDamage: false
 
 - type: entity
   id: CP14ImpactEffectMagicBallade

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/freeze.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/freeze.yml
@@ -31,8 +31,8 @@
   - type: CP14MagicEffectVerbalAspect
     startSpeech: "Vos adepto frigus..."
   - type: CP14MagicEffectCastingVisual
-  - type: CP14MagicEffectPacifiedBlock
     proto: CP14RunePlantFreeze
+  - type: CP14MagicEffectPacifiedBlock
   - type: Action
     icon:
       sprite: _CP14/Actions/Spells/water.rsi

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/freeze.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/freeze.yml
@@ -31,6 +31,7 @@
   - type: CP14MagicEffectVerbalAspect
     startSpeech: "Vos adepto frigus..."
   - type: CP14MagicEffectCastingVisual
+  - type: CP14MagicEffectPacifiedBlock
     proto: CP14RunePlantFreeze
   - type: Action
     icon:

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/ice_shards.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Water/ice_shards.yml
@@ -64,8 +64,8 @@
   - type: Projectile
     damage:
       types:
-        Cold: 6
-        Piercing: 2
+        Cold: 5
+        Piercing: 2.5
   - type: Sprite
     sprite: _CP14/Effects/Magic/ice_shard.rsi
     layers:


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Iceshard now does 5 cold 2.5 pierce, fire wave nolonger adjusts the temp inside of someone and now has a cast time of 0.5 seconds (does not break on damage or move), all ballade spells now do not break on damage.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
some of these spells are heavily under utilized and ice shard got a bit too big a buff and firewave one shots a skeleton if all connects due to the temp adjust.
## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
-->
:cl:
- tweak: Changed Ice shard to now do 2.5 pierce and 5 cold total of 7.5 damage.
- tweak: Changed Fire wave to now have a 0.5 second cast time that cannot be interrupted and nolonger adjusts the temperature inside of someone.
- tweak: Changed magic, speed, and hell ballade spells to nolonger break upon being damaged.
- tweak: Changed Hell ballade now takes 8 mana per second and slows you down by 50% speed.
- fix: Fixed hell ballad, heat, and freeze nolonger work while under pacifism.
