### PR TITLE
Price of artifacts

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Drinks/goblet.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Consumable/Drinks/goblet.yml
@@ -92,3 +92,5 @@
     maxTransferAmount: 100
     transferAmount: 1
     toggleState: 1 # draw
+  - type: StaticPrice
+    price: 120

--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/Magic/twoHandedStaffs.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/Magic/twoHandedStaffs.yml
@@ -65,6 +65,8 @@
   - type: CP14MagicEnergyContainer
     energy: 80
     maxEnergy: 80
+  - type: StaticPrice
+    price: 300
 
 - type: entity
   id: CP14MagicShadowStaff
@@ -142,3 +144,5 @@
     maxEnergy: 30
   - type: CP14MagicManacostModify
     globalModifier: 0.9
+  - type: StaticPrice
+    price: 20


### PR DESCRIPTION
## About the PR

Added prices for two artefacts that did not have them previously.
Добавил цену для двух артефактов, которые её ранее не имели.

**Changelog**

:cl:
- add: Added price for artefacts bottomless goblet and magic healing staff.