### PR TITLE
fire magic bad skele

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Mobs/Player/DemiplaneAntag/Skeletons/T2.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/Player/DemiplaneAntag/Skeletons/T2.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: CP14MobUndeadSkeletonDemiplaneT2
-  parent: CP14MobUndeadSkeletonDemiplaneT1 
+  parent: CP14MobUndeadSkeletonDemiplaneT1
   name: skeleton
   abstract: true
   components:
@@ -92,8 +92,8 @@
     - CP14MobSkeletonWizardT2
   - type: CP14MagicEnergyContainer
     magicAlert: CP14MagicEnergy
-    maxEnergy: 200
-    energy: 200
+    maxEnergy: 100
+    energy: 100
     unsafeSupport: true
   - type: PassiveDamage
     allowedStates:
@@ -104,22 +104,27 @@
   - type: CP14SkillStorage
     skillPoints:
       Memory:
-        max: 4
+        max: 5
     freeLearnedSkills:
     - SwordMastery
     - RapierMastery
     - SkimitarMastery
-    - HydrosophistryT1
-    - HydrosophistryT2
     - MetamagicT1
     - MetamagicT2
-    - PyrokineticT1
     - CP14ActionSpellManaConsume
     - CP14ActionSpellManaGift
     - CP14ActionSpellManaConsumeElf
     - CP14ActionSpellManaGiftElf
     - CP14ActionSpellMagicSplitting
     - CP14ActionSpellManaTrance
+    availableSkillTrees:
+    - Hydrosophistry
+    - Illusion
+    - Metamagic
+    - Electromancy
+    - Athletic
+    - MartialArts
+    - Craftsmanship
 - type: entity
   id: CP14MobUndeadSkeletonBardT2
   parent: CP14MobUndeadSkeletonDemiplaneT2

--- a/Resources/Prototypes/_CP14/Entities/Mobs/Player/TownRaids/undead.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/Player/TownRaids/undead.yml
@@ -53,23 +53,27 @@
   - type: CP14SkillStorage
     skillPoints:
       Memory:
-        max: 4
+        max: 5
     freeLearnedSkills:
     - SwordMastery
     - RapierMastery
     - SkimitarMastery
     - MetamagicT1
     - MetamagicT2
-    - HydrosophistryT1
-    - HydrosophistryT2
-    - PyrokineticT1
-    - PyrokineticT2
     - CP14ActionSpellManaConsume
     - CP14ActionSpellManaGift
     - CP14ActionSpellManaConsumeElf
     - CP14ActionSpellManaGiftElf
     - CP14ActionSpellMagicSplitting
     - CP14ActionSpellManaTrance
+    availableSkillTrees:
+    - Hydrosophistry
+    - Illusion
+    - Metamagic
+    - Electromancy
+    - Athletic
+    - MartialArts
+    - Craftsmanship
   - type: Loadout
     prototypes:
     - CP14MobSkeletonWizardTownRaid


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
removed fire and healing trees from skeletons and made it so thier innate skills include only metamagic 5 max memory
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
fireball bad when used by skele
**Changelog**
not needed as this was not even something most players were aware of
