### PR TITLE
Make elfs & silvas always use female displacement

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Mobs/Species/elf.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/Species/elf.yml
@@ -41,12 +41,17 @@
   - type: Inventory
     templateId: CP14Human
     displacements:
+      outerClothing:
+        sizeMaps:
+          32:
+            sprite: _CP14/Mobs/Species/Human/displacement.rsi
+            state: female_cloak
       cloak:
         sizeMaps:
           32:
             sprite: _CP14/Mobs/Species/Human/displacement.rsi
             state: female_cloak
-      outerClothing:
+      gloves:
         sizeMaps:
           32:
             sprite: _CP14/Mobs/Species/Human/displacement.rsi
@@ -62,6 +67,26 @@
             sprite: _CP14/Mobs/Species/Elf/displacement.rsi
             state: male_shirt
     femaleDisplacements:
+      outerClothing:
+        sizeMaps:
+          32:
+            sprite: _CP14/Mobs/Species/Human/displacement.rsi
+            state: female_cloak
+      cloak:
+        sizeMaps:
+          32:
+            sprite: _CP14/Mobs/Species/Human/displacement.rsi
+            state: female_cloak
+      gloves:
+        sizeMaps:
+          32:
+            sprite: _CP14/Mobs/Species/Human/displacement.rsi
+            state: female_cloak
+      pants:
+        sizeMaps:
+          32:
+            sprite: _CP14/Mobs/Species/Human/displacement.rsi
+            state: female_pants
       shirt:
         sizeMaps:
           32:
@@ -78,12 +103,17 @@
   - type: Inventory
     templateId: CP14Human
     displacements:
+      outerClothing:
+        sizeMaps:
+          32:
+            sprite: _CP14/Mobs/Species/Human/displacement.rsi
+            state: female_cloak
       cloak:
         sizeMaps:
           32:
             sprite: _CP14/Mobs/Species/Human/displacement.rsi
             state: female_cloak
-      outerClothing:
+      gloves:
         sizeMaps:
           32:
             sprite: _CP14/Mobs/Species/Human/displacement.rsi
@@ -99,6 +129,26 @@
             sprite: _CP14/Mobs/Species/Elf/displacement.rsi
             state: male_shirt
     femaleDisplacements:
+      outerClothing:
+        sizeMaps:
+          32:
+            sprite: _CP14/Mobs/Species/Human/displacement.rsi
+            state: female_cloak
+      cloak:
+        sizeMaps:
+          32:
+            sprite: _CP14/Mobs/Species/Human/displacement.rsi
+            state: female_cloak
+      gloves:
+        sizeMaps:
+          32:
+            sprite: _CP14/Mobs/Species/Human/displacement.rsi
+            state: female_cloak
+      pants:
+        sizeMaps:
+          32:
+            sprite: _CP14/Mobs/Species/Human/displacement.rsi
+            state: female_pants
       shirt:
         sizeMaps:
           32:

--- a/Resources/Prototypes/_CP14/Entities/Mobs/Species/silva.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/Species/silva.yml
@@ -100,6 +100,26 @@
             sprite: _CP14/Mobs/Species/Elf/displacement.rsi
             state: male_shirt
     femaleDisplacements:
+      outerClothing:
+        sizeMaps:
+          32:
+            sprite: _CP14/Mobs/Species/Human/displacement.rsi
+            state: female_cloak
+      cloak:
+        sizeMaps:
+          32:
+            sprite: _CP14/Mobs/Species/Human/displacement.rsi
+            state: female_cloak
+      gloves:
+        sizeMaps:
+          32:
+            sprite: _CP14/Mobs/Species/Human/displacement.rsi
+            state: female_cloak
+      pants:
+        sizeMaps:
+          32:
+            sprite: _CP14/Mobs/Species/Human/displacement.rsi
+            state: female_pants
       shirt:
         sizeMaps:
           32:
@@ -165,12 +185,17 @@
   - type: Inventory
     templateId: CP14Human
     displacements:
+      outerClothing:
+        sizeMaps:
+          32:
+            sprite: _CP14/Mobs/Species/Human/displacement.rsi
+            state: female_cloak
       cloak:
         sizeMaps:
           32:
             sprite: _CP14/Mobs/Species/Human/displacement.rsi
             state: female_cloak
-      outerClothing:
+      gloves:
         sizeMaps:
           32:
             sprite: _CP14/Mobs/Species/Human/displacement.rsi
@@ -186,6 +211,26 @@
             sprite: _CP14/Mobs/Species/Elf/displacement.rsi
             state: male_shirt
     femaleDisplacements:
+      outerClothing:
+        sizeMaps:
+          32:
+            sprite: _CP14/Mobs/Species/Human/displacement.rsi
+            state: female_cloak
+      cloak:
+        sizeMaps:
+          32:
+            sprite: _CP14/Mobs/Species/Human/displacement.rsi
+            state: female_cloak
+      gloves:
+        sizeMaps:
+          32:
+            sprite: _CP14/Mobs/Species/Human/displacement.rsi
+            state: female_cloak
+      pants:
+        sizeMaps:
+          32:
+            sprite: _CP14/Mobs/Species/Human/displacement.rsi
+            state: female_pants
       shirt:
         sizeMaps:
           32:


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Fix #1379 

Because base sprite of male/female of elfs and silvas is same as human female we force always to use female displacement.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->
https://github.com/user-attachments/assets/ecfd91ff-abf0-4add-9be9-47247f02e0b3

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
-->

:cl:
- fix: Silvas and Elfs clothing now always displayed as female
