### PR TITLE
Balance tweaks

### DIFF
--- a/Content.Client/_CP14/IdentityRecognition/CP14IdentityRecognitionBoundUserInterface.cs
+++ b/Content.Client/_CP14/IdentityRecognition/CP14IdentityRecognitionBoundUserInterface.cs
@@ -87,10 +87,6 @@ public sealed class CP14IdentityRecognitionBoundUserInterface : BoundUserInterfa
         {
             case CP14RememberNameUiState rememberNameUiState:
                 _rememberedTarget = rememberNameUiState.Target;
-
-                var currentName = CurrentName();
-                if (currentName is not null)
-                    _window.SetCurrentLabel(currentName);
                 break;
         }
     }

--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -62,7 +62,7 @@ namespace Content.IntegrationTests.Tests
                 }
             });
 
-            await server.WaitRunTicks(15 * 60); // 15 seconds, enough to trigger most update loops
+            await server.WaitRunTicks(15);
 
             await server.WaitPost(() =>
             {
@@ -125,7 +125,7 @@ namespace Content.IntegrationTests.Tests
                     entityMan.SpawnEntity(protoId, map.GridCoords);
                 }
             });
-            await server.WaitRunTicks(15 * 60); // 15 seconds, enough to trigger most update loops
+            await server.WaitRunTicks(15);
             await server.WaitPost(() =>
             {
                 static IEnumerable<(EntityUid, TComp)> Query<TComp>(IEntityManager entityMan)
@@ -200,7 +200,7 @@ namespace Content.IntegrationTests.Tests
                 }
             });
 
-            await pair.RunTicksSync(15 * 60);
+            await pair.RunTicksSync(15);
 
             // Make sure the client actually received the entities
             // 500 is completely arbitrary. Note that the client & sever entity counts aren't expected to match.

--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -34,6 +34,7 @@ namespace Content.IntegrationTests.Tests
             var prototypeMan = server.ResolveDependency<IPrototypeManager>();
             var mapSystem = entityMan.System<SharedMapSystem>();
 
+            var forkFiltered = prototypeMan.Index<EntityCategoryPrototype>("ForkFiltered"); //CP14
             await server.WaitPost(() =>
             {
                 var protoIds = prototypeMan
@@ -45,8 +46,7 @@ namespace Content.IntegrationTests.Tests
                     //CP14
                     .Where(p => !p.Components.ContainsKey("CP14BiomeSpawner")) // this component delete all entities on this tile
                     .Where(p => !p.Components.ContainsKey("CP14AreaEntityEffect")) // lightning detonates entities
-                    .Where(p => !p.Components.ContainsKey("CP14VampireClanHeart")) //Roundstart sounds spawning
-                    .Where(p => p.Categories.Contains(prototypeMan.Index<EntityCategoryPrototype>("ForkFiltered"))) //CP14 only entities
+                    .Where(p => p.Categories.Contains(forkFiltered)) //CP14 only entities
                     //CP14 end
                     .Select(p => p.ID)
                     .ToList();
@@ -102,6 +102,8 @@ namespace Content.IntegrationTests.Tests
             var entityMan = server.ResolveDependency<IEntityManager>();
             var prototypeMan = server.ResolveDependency<IPrototypeManager>();
 
+            var forkFiltered = prototypeMan.Index<EntityCategoryPrototype>("ForkFiltered"); //CP14
+
             await server.WaitPost(() =>
             {
 
@@ -114,8 +116,7 @@ namespace Content.IntegrationTests.Tests
                     //CP14
                     .Where(p => !p.Components.ContainsKey("CP14BiomeSpawner")) // CP14 this component delete all entities on this tile
                     .Where(p => !p.Components.ContainsKey("CP14AreaEntityEffect")) // CP14 lightning detonates entities
-                    .Where(p => !p.Components.ContainsKey("CP14VampireClanHeart")) //Roundstart sounds spawning
-                    .Where(p => p.Categories.Contains(prototypeMan.Index<EntityCategoryPrototype>("ForkFiltered"))) //CP14 only entities
+                    .Where(p => p.Categories.Contains(forkFiltered)) //CP14 only entities
                     //CP14 end
                     .Select(p => p.ID)
                     .ToList();
@@ -170,6 +171,8 @@ namespace Content.IntegrationTests.Tests
             var sEntMan = server.ResolveDependency<IEntityManager>();
             var mapSys = server.System<SharedMapSystem>();
 
+            var forkFiltered = prototypeMan.Index<EntityCategoryPrototype>("ForkFiltered"); //CP14
+
             Assert.That(cfg.GetCVar(CVars.NetPVS), Is.False);
 
             var protoIds = prototypeMan
@@ -178,8 +181,7 @@ namespace Content.IntegrationTests.Tests
                 .Where(p => !pair.IsTestPrototype(p))
                 .Where(p => !p.Components.ContainsKey("MapGrid")) // This will smash stuff otherwise.
                 //CP14
-                .Where(p => p.Categories.Contains(prototypeMan.Index<EntityCategoryPrototype>("ForkFiltered"))) //CP14 only entities
-                .Where(p => !p.Components.ContainsKey("CP14VampireClanHeart")) //Roundstart sounds spawning
+                .Where(p => p.Categories.Contains(forkFiltered)) //CP14 only entities
                 //CP14 end
                 .Select(p => p.ID)
                 .ToList();

--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -42,8 +42,12 @@ namespace Content.IntegrationTests.Tests
                     .Where(p => !pair.IsTestPrototype(p))
                     .Where(p => !p.Components.ContainsKey("MapGrid")) // This will smash stuff otherwise.
                     .Where(p => !p.Components.ContainsKey("RoomFill")) // This comp can delete all entities, and spawn others
-                    .Where(p => !p.Components.ContainsKey("CP14BiomeSpawner")) // CP14 this component delete all entities on this tile
-                    .Where(p => !p.Components.ContainsKey("CP14AreaEntityEffect")) // CP14 lightning detonates entities
+                    //CP14
+                    .Where(p => !p.Components.ContainsKey("CP14BiomeSpawner")) // this component delete all entities on this tile
+                    .Where(p => !p.Components.ContainsKey("CP14AreaEntityEffect")) // lightning detonates entities
+                    .Where(p => !p.Components.ContainsKey("CP14VampireClanHeart")) //Roundstart sounds spawning
+                    .Where(p => p.Categories.Contains(prototypeMan.Index<EntityCategoryPrototype>("ForkFiltered"))) //CP14 only entities
+                    //CP14 end
                     .Select(p => p.ID)
                     .ToList();
 
@@ -107,8 +111,12 @@ namespace Content.IntegrationTests.Tests
                     .Where(p => !pair.IsTestPrototype(p))
                     .Where(p => !p.Components.ContainsKey("MapGrid")) // This will smash stuff otherwise.
                     .Where(p => !p.Components.ContainsKey("RoomFill")) // This comp can delete all entities, and spawn others
+                    //CP14
                     .Where(p => !p.Components.ContainsKey("CP14BiomeSpawner")) // CP14 this component delete all entities on this tile
                     .Where(p => !p.Components.ContainsKey("CP14AreaEntityEffect")) // CP14 lightning detonates entities
+                    .Where(p => !p.Components.ContainsKey("CP14VampireClanHeart")) //Roundstart sounds spawning
+                    .Where(p => p.Categories.Contains(prototypeMan.Index<EntityCategoryPrototype>("ForkFiltered"))) //CP14 only entities
+                    //CP14 end
                     .Select(p => p.ID)
                     .ToList();
                 foreach (var protoId in protoIds)
@@ -169,6 +177,10 @@ namespace Content.IntegrationTests.Tests
                 .Where(p => !p.Abstract)
                 .Where(p => !pair.IsTestPrototype(p))
                 .Where(p => !p.Components.ContainsKey("MapGrid")) // This will smash stuff otherwise.
+                //CP14
+                .Where(p => p.Categories.Contains(prototypeMan.Index<EntityCategoryPrototype>("ForkFiltered"))) //CP14 only entities
+                .Where(p => !p.Components.ContainsKey("CP14VampireClanHeart")) //Roundstart sounds spawning
+                //CP14 end
                 .Select(p => p.ID)
                 .ToList();
 

--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -262,6 +262,9 @@ namespace Content.IntegrationTests.Tests
 
                 // makes an announcement on mapInit.
                 "AnnounceOnSpawn",
+                //CP14
+                "CP14VampireClanHeart", //Also announce on spawn
+                //CP14 end
             };
 
             Assert.That(server.CfgMan.GetCVar(CVars.NetPVS), Is.False);

--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -174,6 +174,7 @@ namespace Content.IntegrationTests.Tests
                 .Where(p => !pair.IsTestPrototype(p))
                 .Where(p => !p.Components.ContainsKey("MapGrid")) // This will smash stuff otherwise.
                 //CP14
+                .Where(p => !p.Components.ContainsKey("CP14VampireClanHeart")) //Spawn announcement sound entities on init
                 //CP14 end
                 .Select(p => p.ID)
                 .ToList();
@@ -392,8 +393,6 @@ namespace Content.IntegrationTests.Tests
                 "DebugExceptionStartup",
                 "GridFill",
                 "RoomFill",
-                "CP14BiomeSpawner", // CP14 this component delete all entities on this tile
-                "CP14AreaEntityEffect", // CP14 lightning detonates entities
                 "Map", // We aren't testing a map entity in this test
                 "MapGrid",
                 "Broadphase",

--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -34,7 +34,6 @@ namespace Content.IntegrationTests.Tests
             var prototypeMan = server.ResolveDependency<IPrototypeManager>();
             var mapSystem = entityMan.System<SharedMapSystem>();
 
-            var forkFiltered = prototypeMan.Index<EntityCategoryPrototype>("ForkFiltered"); //CP14
             await server.WaitPost(() =>
             {
                 var protoIds = prototypeMan
@@ -46,7 +45,6 @@ namespace Content.IntegrationTests.Tests
                     //CP14
                     .Where(p => !p.Components.ContainsKey("CP14BiomeSpawner")) // this component delete all entities on this tile
                     .Where(p => !p.Components.ContainsKey("CP14AreaEntityEffect")) // lightning detonates entities
-                    .Where(p => p.Categories.Contains(forkFiltered)) //CP14 only entities
                     //CP14 end
                     .Select(p => p.ID)
                     .ToList();
@@ -102,8 +100,6 @@ namespace Content.IntegrationTests.Tests
             var entityMan = server.ResolveDependency<IEntityManager>();
             var prototypeMan = server.ResolveDependency<IPrototypeManager>();
 
-            var forkFiltered = prototypeMan.Index<EntityCategoryPrototype>("ForkFiltered"); //CP14
-
             await server.WaitPost(() =>
             {
 
@@ -116,7 +112,6 @@ namespace Content.IntegrationTests.Tests
                     //CP14
                     .Where(p => !p.Components.ContainsKey("CP14BiomeSpawner")) // CP14 this component delete all entities on this tile
                     .Where(p => !p.Components.ContainsKey("CP14AreaEntityEffect")) // CP14 lightning detonates entities
-                    .Where(p => p.Categories.Contains(forkFiltered)) //CP14 only entities
                     //CP14 end
                     .Select(p => p.ID)
                     .ToList();
@@ -171,8 +166,6 @@ namespace Content.IntegrationTests.Tests
             var sEntMan = server.ResolveDependency<IEntityManager>();
             var mapSys = server.System<SharedMapSystem>();
 
-            var forkFiltered = prototypeMan.Index<EntityCategoryPrototype>("ForkFiltered"); //CP14
-
             Assert.That(cfg.GetCVar(CVars.NetPVS), Is.False);
 
             var protoIds = prototypeMan
@@ -181,7 +174,6 @@ namespace Content.IntegrationTests.Tests
                 .Where(p => !pair.IsTestPrototype(p))
                 .Where(p => !p.Components.ContainsKey("MapGrid")) // This will smash stuff otherwise.
                 //CP14
-                .Where(p => p.Categories.Contains(forkFiltered)) //CP14 only entities
                 //CP14 end
                 .Select(p => p.ID)
                 .ToList();

--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -62,7 +62,7 @@ namespace Content.IntegrationTests.Tests
                 }
             });
 
-            await server.WaitRunTicks(15); // 15 seconds, enough to trigger most update loops //CP14 returned back to 15 ticks (operation was cancelled github issue)
+            await server.WaitRunTicks(15 * 60); // 15 seconds, enough to trigger most update loops
 
             await server.WaitPost(() =>
             {
@@ -125,7 +125,7 @@ namespace Content.IntegrationTests.Tests
                     entityMan.SpawnEntity(protoId, map.GridCoords);
                 }
             });
-            await server.WaitRunTicks(15); // 15 seconds, enough to trigger most update loops //CP14 returned back to 15 ticks (operation was cancelled github issue)
+            await server.WaitRunTicks(15 * 60); // 15 seconds, enough to trigger most update loops
             await server.WaitPost(() =>
             {
                 static IEnumerable<(EntityUid, TComp)> Query<TComp>(IEntityManager entityMan)
@@ -200,7 +200,7 @@ namespace Content.IntegrationTests.Tests
                 }
             });
 
-            await pair.RunTicksSync(15);
+            await pair.RunTicksSync(15 * 60);
 
             // Make sure the client actually received the entities
             // 500 is completely arbitrary. Note that the client & sever entity counts aren't expected to match.

--- a/Content.Server/_CP14/GameTicking/Rules/CP14VampireRuleSystem.cs
+++ b/Content.Server/_CP14/GameTicking/Rules/CP14VampireRuleSystem.cs
@@ -29,16 +29,16 @@ public sealed class CP14VampireRuleSystem : GameRuleSystem<CP14VampireRuleCompon
 
         var aliveFactions = new HashSet<ProtoId<CP14VampireFactionPrototype>>();
 
-        var query = EntityQueryEnumerator<CP14VampireComponent, MobStateComponent>();
-        while (query.MoveNext(out var vampireUid, out var vampire, out var mobState))
+        var query = EntityQueryEnumerator<CP14VampireClanHeartComponent>();
+        while (query.MoveNext(out _, out var heart))
         {
-            if (mobState.CurrentState != MobState.Alive)
+            if (heart.Faction is null)
                 continue;
 
-            if (vampire.Faction is null)
+            if (heart.Level < _condition.RequiredHeartLevel)
                 continue;
 
-            aliveFactions.Add(vampire.Faction.Value);
+            aliveFactions.Add(heart.Faction.Value);
         }
 
         args.AddLine($"[head=2][color=#ab1b3d]{Loc.GetString("cp14-vampire-clans-battle")}[/color][/head]");

--- a/Content.Server/_CP14/Objectives/Systems/CP14VampireObjectiveConditionsSystem.cs
+++ b/Content.Server/_CP14/Objectives/Systems/CP14VampireObjectiveConditionsSystem.cs
@@ -104,7 +104,7 @@ public sealed class CP14VampireObjectiveConditionsSystem : EntitySystem
             if (vampire.Faction != ent.Comp.Faction && vampire.Level >= RequiredHeartLevel)
             {
                 othersHeartsExist = true;
-                return;
+                break;
             }
         }
 

--- a/Content.Server/_CP14/Objectives/Systems/CP14VampireObjectiveConditionsSystem.cs
+++ b/Content.Server/_CP14/Objectives/Systems/CP14VampireObjectiveConditionsSystem.cs
@@ -22,6 +22,7 @@ public sealed class CP14VampireObjectiveConditionsSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _proto = default!;
 
     public readonly float RequiredAlivePercentage = 0.5f;
+    public readonly int RequiredHeartLevel = 3;
 
     public override void Initialize()
     {
@@ -84,27 +85,37 @@ public sealed class CP14VampireObjectiveConditionsSystem : EntitySystem
 
          ent.Comp.Faction = vampireComp.Faction;
 
-         _meta.SetEntityName(ent, Loc.GetString("cp14-objective-vampire-pure-bood-title"));
-         _meta.SetEntityDescription(ent, Loc.GetString("cp14-objective-vampire-pure-bood-desc"));
+         _meta.SetEntityName(ent, Loc.GetString("cp14-objective-vampire-pure-blood-title"));
+         _meta.SetEntityDescription(ent, Loc.GetString("cp14-objective-vampire-pure-blood-desc"));
          _objectives.SetIcon(ent, ent.Comp.Icon);
     }
 
     private void OnBloodPurityGetProgress(Entity<CP14VampireBloodPurityConditionComponent> ent, ref ObjectiveGetProgressEvent args)
     {
-        var query = EntityQueryEnumerator<CP14VampireComponent, MobStateComponent>();
+        var query = EntityQueryEnumerator<CP14VampireClanHeartComponent>();
 
-        while (query.MoveNext(out var uid, out var vampire, out var mobState))
+        var ourHeartReady = false;
+        var othersHeartsExist = false;
+        while (query.MoveNext(out var uid, out var vampire))
         {
-            if (vampire.Faction != ent.Comp.Faction)
-            {
-                if (mobState.CurrentState == MobState.Dead)
-                    continue;
+            if (vampire.Faction == ent.Comp.Faction && vampire.Level >= RequiredHeartLevel)
+                ourHeartReady = true;
 
-                args.Progress = 0f;
+            if (vampire.Faction != ent.Comp.Faction && vampire.Level >= RequiredHeartLevel)
+            {
+                othersHeartsExist = true;
                 return;
             }
         }
 
-        args.Progress = 1f;
+        var progress = 0f;
+
+        if (ourHeartReady)
+            progress += 0.5f;
+
+        if (!othersHeartsExist)
+            progress += 0.5f;
+
+        args.Progress = progress;
     }
 }

--- a/Content.Server/_CP14/RoundEnd/CP14RoundEndSystem.CBT.cs
+++ b/Content.Server/_CP14/RoundEnd/CP14RoundEndSystem.CBT.cs
@@ -125,6 +125,13 @@ public sealed partial class CP14RoundEndSystem
                     sender: "Server"
                 );
             }),
+            (22, 0, () =>
+            {
+                if (!ruDays)
+                    return;
+
+                _consoleHost.ExecuteCommand("endround");
+            }),
             (22, 2, () =>
             {
                 if (!ruDays)
@@ -142,6 +149,13 @@ public sealed partial class CP14RoundEndSystem
                     announcementSound: new SoundPathSpecifier("/Audio/Effects/beep1.ogg"),
                     sender: "Server"
                 );
+            }),
+            (23, 58, () =>
+            {
+                if (ruDays)
+                    return;
+
+                _consoleHost.ExecuteCommand("endround");
             }),
             (23, 59, () =>
             {

--- a/Content.Server/_CP14/Vampire/CP14VampireSystem.Announce.cs
+++ b/Content.Server/_CP14/Vampire/CP14VampireSystem.Announce.cs
@@ -17,10 +17,22 @@ public sealed partial class CP14VampireSystem
 
     private void InitializeAnnounces()
     {
+        SubscribeLocalEvent<CP14VampireClanHeartComponent, MapInitEvent>(OnHeartCreate);
         SubscribeLocalEvent<CP14VampireClanHeartComponent, DamageChangedEvent>(OnHeartDamaged);
         SubscribeLocalEvent<CP14VampireClanHeartComponent, ComponentRemove>(OnHeartDestructed);
     }
 
+    private void OnHeartCreate(Entity<CP14VampireClanHeartComponent> ent, ref MapInitEvent args)
+    {
+        if (ent.Comp.Faction is null)
+            return;
+
+        if (!Proto.TryIndex(ent.Comp.Faction, out var indexedFaction))
+            return;
+
+        AnnounceToFaction(ent.Comp.Faction.Value, Loc.GetString("cp14-vampire-tree-created", ("name", Loc.GetString(indexedFaction.Name))));
+        AnnounceToOpposingFactions(ent.Comp.Faction.Value, Loc.GetString("cp14-vampire-tree-created", ("name", Loc.GetString(indexedFaction.Name))));
+    }
 
     private void OnHeartDamaged(Entity<CP14VampireClanHeartComponent> ent, ref DamageChangedEvent args)
     {

--- a/Content.Server/_CP14/Vampire/CP14VampireSystem.Announce.cs
+++ b/Content.Server/_CP14/Vampire/CP14VampireSystem.Announce.cs
@@ -1,11 +1,8 @@
-using System.Text;
+using Content.Server.Administration.Managers;
 using Content.Server.Chat.Systems;
 using Content.Shared._CP14.Vampire;
 using Content.Shared._CP14.Vampire.Components;
 using Content.Shared.Damage;
-using Content.Shared.Destructible;
-using Content.Shared.Examine;
-using Content.Shared.Ghost;
 using Robust.Shared.Audio;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
@@ -16,6 +13,7 @@ public sealed partial class CP14VampireSystem
 {
     [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly IAdminManager _admin = default!;
 
     private void InitializeAnnounces()
     {
@@ -82,6 +80,11 @@ public sealed partial class CP14VampireSystem
                 continue;
 
             filter.AddPlayer(actor.PlayerSession);
+        }
+
+        foreach (var adminSession in _admin.ActiveAdmins)
+        {
+            filter.AddPlayer(adminSession);
         }
 
         if (filter.Count == 0)

--- a/Content.Server/_CP14/Vampire/CP14VampireSystem.Announce.cs
+++ b/Content.Server/_CP14/Vampire/CP14VampireSystem.Announce.cs
@@ -94,10 +94,7 @@ public sealed partial class CP14VampireSystem
             filter.AddPlayer(actor.PlayerSession);
         }
 
-        foreach (var adminSession in _admin.ActiveAdmins)
-        {
-            filter.AddPlayer(adminSession);
-        }
+        filter.AddPlayers(_admin.ActiveAdmins);
 
         if (filter.Count == 0)
             return;

--- a/Content.Server/_CP14/Vampire/CP14VampireSystem.cs
+++ b/Content.Server/_CP14/Vampire/CP14VampireSystem.cs
@@ -170,7 +170,7 @@ public sealed partial class CP14VampireSystem : CP14SharedVampireSystem
 
             heart.NextRegenTime = _timing.CurTime + heart.RegenFrequency;
 
-            AddEssence((uid, heart), heart.EssenceRegenPerLevel * heart.Level);
+            AddEssence((uid, heart), heart.EssenceRegen);
         }
     }
 }

--- a/Content.Shared/_CP14/IdentityRecognition/CP14SharedIdentityRecognitionSystem.cs
+++ b/Content.Shared/_CP14/IdentityRecognition/CP14SharedIdentityRecognitionSystem.cs
@@ -1,9 +1,9 @@
 using Content.Shared.Examine;
 using Content.Shared.Ghost;
-using Content.Shared.IdentityManagement;
 using Content.Shared.IdentityManagement.Components;
 using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
+using Content.Shared.Popups;
 using Content.Shared.Verbs;
 using Robust.Shared.Player;
 using Robust.Shared.Serialization;
@@ -15,7 +15,7 @@ public abstract class CP14SharedIdentityRecognitionSystem : EntitySystem
 {
     [Dependency] private readonly SharedUserInterfaceSystem _uiSystem = default!;
     [Dependency] private readonly SharedMindSystem _mind = default!;
-    [Dependency] private readonly SharedIdentitySystem _identity = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
 
     public override void Initialize()
     {
@@ -68,11 +68,17 @@ public abstract class CP14SharedIdentityRecognitionSystem : EntitySystem
             Priority = 2,
             Icon =  new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/sentient.svg.192dpi.png")),
             Text = Loc.GetString("cp14-remember-name-verb"),
-            Disabled = seeAttemptEv.Cancelled,
             Act = () =>
             {
-                _uiSystem.SetUiState(_args.User, CP14RememberNameUiKey.Key, new CP14RememberNameUiState(GetNetEntity(ent)));
-                _uiSystem.TryToggleUi(_args.User, CP14RememberNameUiKey.Key, actor.PlayerSession);
+                if (seeAttemptEv.Cancelled)
+                {
+                    _popup.PopupClient(Loc.GetString("cp14-remember-fail-mask"), _args.Target, _args.User);
+                }
+                else
+                {
+                    _uiSystem.SetUiState(_args.User, CP14RememberNameUiKey.Key, new CP14RememberNameUiState(GetNetEntity(ent)));
+                    _uiSystem.TryToggleUi(_args.User, CP14RememberNameUiKey.Key, actor.PlayerSession);
+                }
             },
         };
         args.Verbs.Add(verb);

--- a/Content.Shared/_CP14/MagicSpell/Spells/Vampire/CP14SpellPointerToVampireClan.cs
+++ b/Content.Shared/_CP14/MagicSpell/Spells/Vampire/CP14SpellPointerToVampireClan.cs
@@ -63,5 +63,29 @@ public sealed partial class CP14SpellPointerToVampireClan : CP14SpellEffect
 
             transform.SetWorldRotation(pointer, angle + Angle.FromDegrees(90));
         }
+
+        var heartsInRange = lookup.GetEntitiesInRange<CP14VampireClanHeartComponent>(originEntPosition, SearchRange);
+        foreach (var heart in heartsInRange)
+        {
+            if (!Inversed)
+            {
+                if (heart.Comp.Faction != vampireComponent.Faction)
+                    continue;
+            }
+            else
+            {
+                if (heart.Comp.Faction == vampireComponent.Faction)
+                    continue;
+            }
+
+            var targetPosition = transform.GetWorldPosition(heart);
+
+            //Calculate the rotation
+            Angle angle = new(targetPosition - originPosition);
+
+            var pointer = entManager.Spawn(PointerEntity, new MapCoordinates(originPosition, transform.GetMapId(originEntPosition)));
+
+            transform.SetWorldRotation(pointer, angle + Angle.FromDegrees(90));
+        }
     }
 }

--- a/Content.Shared/_CP14/MagicSpell/Spells/Vampire/CP14SpellTeleportToVampireSingleton.cs
+++ b/Content.Shared/_CP14/MagicSpell/Spells/Vampire/CP14SpellTeleportToVampireSingleton.cs
@@ -44,8 +44,7 @@ public sealed partial class CP14SpellTeleportToVampireSingleton : CP14SpellEffec
             if (singleton.Key != indexedVampireFaction.SingletonTeleportKey)
                 continue;
 
-            var randomOffset = new Vector2(random.Next(-1, 1), random.Next(-1, 1));
-            var second = entManager.SpawnAtPosition(PortalProto, xform.Coordinates.Offset(randomOffset));
+            var second = entManager.SpawnAtPosition(PortalProto, xform.Coordinates);
 
             linkSys.TryLink(first, second, true);
             return;

--- a/Content.Shared/_CP14/Trading/Systems/CP14SharedTradingPlatformSystem.cs
+++ b/Content.Shared/_CP14/Trading/Systems/CP14SharedTradingPlatformSystem.cs
@@ -54,7 +54,7 @@ public abstract partial class CP14SharedTradingPlatformSystem : EntitySystem
         var repComp = EnsureComp<CP14TradingReputationComponent>(args.User);
         repComp.Reputation.TryAdd(ent.Comp.Faction, 0);
         _audio.PlayLocal(new SoundCollectionSpecifier("CP14CoinImpact"), args.User, args.User);
-        _popup.PopupPredicted(Loc.GetString("cp14-trading-contract-use", ("name", Loc.GetString(indexedFaction.Name))), args.User, args.User);
+        _popup.PopupClient(Loc.GetString("cp14-trading-contract-use", ("name", Loc.GetString(indexedFaction.Name))), args.User, args.User);
 
         if (_net.IsServer)
             QueueDel(ent);

--- a/Content.Shared/_CP14/Vampire/Components/CP14VampireClanHeartComponent.cs
+++ b/Content.Shared/_CP14/Vampire/Components/CP14VampireClanHeartComponent.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared._CP14.Vampire.Components;
 
-[RegisterComponent]
+[RegisterComponent, EntityCategory("Spawner")]
 [NetworkedComponent]
 [AutoGenerateComponentState]
 [Access(typeof(CP14SharedVampireSystem))]

--- a/Content.Shared/_CP14/Vampire/Components/CP14VampireClanHeartComponent.cs
+++ b/Content.Shared/_CP14/Vampire/Components/CP14VampireClanHeartComponent.cs
@@ -32,7 +32,7 @@ public sealed partial class CP14VampireClanHeartComponent : Component
     public FixedPoint2 Level4 = 21f;
 
     [DataField]
-    public FixedPoint2 EssenceRegenPerLevel = 0.1f;
+    public FixedPoint2 EssenceRegen = 0.2f;
 
     [DataField]
     public TimeSpan RegenFrequency = TimeSpan.FromMinutes(1);

--- a/Content.Shared/_CP14/Vampire/Components/CP14VampireClanHeartComponent.cs
+++ b/Content.Shared/_CP14/Vampire/Components/CP14VampireClanHeartComponent.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared._CP14.Vampire.Components;
 
-[RegisterComponent, EntityCategory("Spawner")]
+[RegisterComponent]
 [NetworkedComponent]
 [AutoGenerateComponentState]
 [Access(typeof(CP14SharedVampireSystem))]

--- a/Resources/Locale/en-US/_CP14/identity/identity_recognition.ftl
+++ b/Resources/Locale/en-US/_CP14/identity/identity_recognition.ftl
@@ -3,3 +3,4 @@ cp14-remember-name-verb = Remember name
 cp14-remember-name-name = Name
 
 cp14-remember-name-examine = You remember this character as [color=yellow]{$name}[/color]
+cp14-remember-fail-mask = You cannot remember those who hide their faces.

--- a/Resources/Locale/en-US/_CP14/objectives/condition/vampire.ftl
+++ b/Resources/Locale/en-US/_CP14/objectives/condition/vampire.ftl
@@ -1,7 +1,7 @@
 cp14-objective-issuer-vampire = [color="#c20034"]Vampire clan[/color]
 
-cp14-objective-vampire-pure-bood-title = Expel foreign vampire clans
-cp14-objective-vampire-pure-bood-desc = Intruders from other vampire clans are hiding among the residents. Eliminate them so that the settlement belongs only to you.
+cp14-objective-vampire-pure-blood-title = Expel foreign vampire clans
+cp14-objective-vampire-pure-blood-desc = Build your clan's heart to at least level 3, and don't let other clans do it. Only your clan's heart should exist!
 
 cp14-objective-vampire-defence-settlement-title = Keep your property
 cp14-objective-vampire-defence-settlement-desc = The inhabitants of this city are your property and your food. Don't let them die. At least {$count}% of the inhabitants must survive.

--- a/Resources/Locale/en-US/_CP14/vampire/vampire.ftl
+++ b/Resources/Locale/en-US/_CP14/vampire/vampire.ftl
@@ -25,6 +25,7 @@ cp14-vampire-gather-essence-no-left = Здесь больше нет эссен�
 
 cp14-vampire-sender = Vampire instinct
 
+cp14-vampire-tree-created = The heart of the “{$name}” clan has been created!
 cp14-vampire-tree-growing = "{$name}" clan heart grows to level {$level}!
 cp14-vampire-tree-growing-self = Your clan heart grows to level {$level}!
 cp14-vampire-tree-damaged = Your clan's heart has been attacked!

--- a/Resources/Locale/ru-RU/_CP14/identity/identity_recognition.ftl
+++ b/Resources/Locale/ru-RU/_CP14/identity/identity_recognition.ftl
@@ -3,3 +3,4 @@ cp14-remember-name-verb = Запомнить имя
 cp14-remember-name-name = Имя
 
 cp14-remember-name-examine = Вы помните этого персонажа как [color=yellow]{$name}[/color]
+cp14-remember-fail-mask = Вы не можете запомнить тех, кто скрывает свое лицо.

--- a/Resources/Locale/ru-RU/_CP14/objectives/condition/vampire.ftl
+++ b/Resources/Locale/ru-RU/_CP14/objectives/condition/vampire.ftl
@@ -1,7 +1,7 @@
 cp14-objective-issuer-vampire = [color="#c20034"]Клан вампиров[/color]
 
-cp14-objective-vampire-pure-bood-title = Изгнать чужие вампирские кланы
-cp14-objective-vampire-pure-bood-desc = Чужаки из других вампирских кланов скрываются среди жителей. Уничтожьте их, чтобы поселение принадлежало только вам.
+cp14-objective-vampire-pure-blood-title = Стать правителем этих земель
+cp14-objective-vampire-pure-blood-desc = Постройте сердце своего клана минимум 3 уровня, и не позвольте это сделать другим кланам. Только сердце вашего клана должно существовать!
 
 cp14-objective-vampire-defence-settlement-title = Сохранить своё имущество
 cp14-objective-vampire-defence-settlement-desc = Жители этого города - ваше имущество и ваша еда. Не позвольте им умереть. Как минимум {$count}% жителей должны выжить.

--- a/Resources/Locale/ru-RU/_CP14/vampire/vampire.ftl
+++ b/Resources/Locale/ru-RU/_CP14/vampire/vampire.ftl
@@ -25,6 +25,7 @@ cp14-vampire-gather-essence-no-left = There is no more essence here!
 
 cp14-vampire-sender = Вампирское чутье
 
+cp14-vampire-tree-created = Создано сердце клана "{$name}"!
 cp14-vampire-tree-growing = Сердце клана "{$name}" вырастает до {$level} уровня!
 cp14-vampire-tree-growing-self = Ваше сердце клана вырастает до {$level} уровня!
 cp14-vampire-tree-damaged = Ваше сердце клана атаковано!

--- a/Resources/Prototypes/_CP14/Catalog/Fills/closets.yml
+++ b/Resources/Prototypes/_CP14/Catalog/Fills/closets.yml
@@ -5,6 +5,8 @@
   components:
   - type: StorageFill
     contents:
+      - id: CP14WeaponDaggerSickle
+        amount: 2
       - id: CP14HandLabeler
       - id: CP14Lighter
       - id: CP14ManaOperationGlove
@@ -17,23 +19,16 @@
         amount: 1
       - id: CP14Dropper
         amount: 1
-      - id: CP14VialTinyReinforced
-        amount: 1
       - id: CP14VialTiny
         amount: 3
-      - id: CP14VialSmallReinforced
-        amount: 1
       - id: CP14VialSmall
         amount: 3
-      - id: CP14VialSkullReinforced
-        prob: 0.3
       - id: CP14VialSkull
         prob: 0.5
       - id: CP14PaperFolderBlue
       - id: CP14PenFeather
         amount: 1
       - id: CP14WoodenPlanks20
-        #Random start resource
       - id: CP14VialMediumEarthEssence
       - id: CP14VialMediumFireEssence
       - id: CP14VialMediumWaterEssence
@@ -106,16 +101,20 @@
   components:
   - type: StorageFill
     contents:
+      - id: CP14WeaponFork
+        amount: 2
       - id: CP14Fork
         amount: 2
       - id: CP14Spoon
         amount: 2
+      - id: CP14WeaponDaggerHatchet
+        amount: 2
       - id: CP14FryingPan
       - id: CP14CookingPot
-      - id: CP14SackFarmingSeed
       - id: CP14PlateWooden
         amount: 2
       - id: CP14BowlWooden
         amount: 2
       - id: CP14BookTieflingGambit
       - id: CP14GuidebookCooking
+      - id: CP14SackFarmingSeedFull

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/air_saturation.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Life/air_saturation.yml
@@ -18,7 +18,7 @@
       - !type:HealthChange
         damage:
           types:
-            Asphyxiation: -2
+            Asphyxiation: -5
       - !type:Jitter
   - type: CP14MagicEffectCastingVisual
     proto: CP14RuneAirSaturation

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Meta/mana_splitting.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Meta/mana_splitting.yml
@@ -20,7 +20,7 @@
     - !type:CP14SpellApplyEntityEffect
       effects:
       - !type:CP14ManaChange
-        manaDelta: -15
+        manaDelta: -5
         safe: false
   - type: CP14MagicEffectCastingVisual
     proto: CP14RuneMagicSplitting

--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Vampire/search_vampire.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Vampire/search_vampire.yml
@@ -29,7 +29,7 @@
   parent: CP14ActionSpellBloodConnection
   id: CP14ActionSpellBloodEnemySearch
   name: Blood identification
-  description: You are searching within a large radius for all vampires from other factions.
+  description: You are searching within a large radius for all vampires from other factions and their clan hearts.
   components:
   - type: CP14MagicEffect
     effects:

--- a/Resources/Prototypes/_CP14/Entities/Mobs/Player/DemiplaneAntag/lurker.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/Player/DemiplaneAntag/lurker.yml
@@ -81,8 +81,6 @@
     - id: CP14ClothingMaskBoneHornedMask
       amount: 1
   - type: FloorOcclusion
-  - type: Puller
-    needsHands: false
   - type: GhostTakeoverAvailable
   - type: TypingIndicator
     proto: alien

--- a/Resources/Prototypes/_CP14/Skill/Vampire/vampire.yml
+++ b/Resources/Prototypes/_CP14/Skill/Vampire/vampire.yml
@@ -238,7 +238,7 @@
 
 - type: cp14Skill
   id: BloodEnemySearch
-  skillUiPosition: 10, 10
+  skillUiPosition: 6, 10
   learnCost: 1
   tree: Vampire
   icon:
@@ -251,7 +251,7 @@
   - !type:NeedPrerequisite
     prerequisite: BloodConnection
   - !type:VampireClanLevel
-    level: 3
+    level: 2
 
 - type: cp14Skill
   id: PortalToVampireHome


### PR DESCRIPTION
:cl:
- add: Innkeepers now have starting seeds, hoes, and hatchets, while alchemists have roundstart sickles.
- fix: If you try to remember the name of a person wearing a mask, a warning will appear stating that you cannot remember the name of a person who is hiding their face.
- add: Admins can now also see vampire notifications about clan heart progression.
- remove: Lurkers can no longer pull items and mobs.
- fix: The teleport spell to the vampire glyph no longer has a random 1-tile shift, which caused people to get stuck in walls.
- tweak: The spell to search for enemy vampire clans is now T2 instead of T3, and also now points to enemy hearts.
- tweak: Changed the main goal of the vampire clan: Now the clan must upgrade its heart to level 3 and prevent other clans from doing so.
- fix: The suffocation healing spell now heals suffocation much more effectively.
