### PR TITLE
Merchant UI changes

### DIFF
--- a/Resources/Prototypes/_CP14/Trading/BuyPositions/brad_potions.yml
+++ b/Resources/Prototypes/_CP14/Trading/BuyPositions/brad_potions.yml
@@ -252,7 +252,7 @@
   reputationLevel: 3
   priceMarkup: 2
   faction: BradPotions
-  uiPosition: 2
+  uiPosition: 3
   icon:
     sprite: _CP14/Objects/Specific/Alchemy/vial_skull.rsi
     state: vial
@@ -264,7 +264,7 @@
   reputationLevel: 3
   priceMarkup: 3
   faction: BradPotions
-  uiPosition: 3
+  uiPosition: 4
   icon:
     sprite: _CP14/Objects/Specific/Alchemy/vial_skull.rsi
     state: vial

--- a/Resources/Prototypes/_CP14/Trading/BuyPositions/thaumaturgy.yml
+++ b/Resources/Prototypes/_CP14/Trading/BuyPositions/thaumaturgy.yml
@@ -38,7 +38,7 @@
   faction: Thaumaturgy
   priceMarkup: 5
   reputationLevel: 0
-  uiPosition: 6
+  uiPosition: 5
   icon:
     sprite: _CP14/Actions/Spells/dimension.rsi
     state: shadow_grab
@@ -50,7 +50,7 @@
   faction: Thaumaturgy
   priceMarkup: 1
   reputationLevel: 0
-  uiPosition: 7
+  uiPosition: 6
   icon:
     sprite: _CP14/Actions/Spells/dimension.rsi
     state: demi_arrow
@@ -61,7 +61,7 @@
   id: CP14SpellScrollFlameCreation
   faction: Thaumaturgy
   reputationLevel: 0
-  uiPosition: 8
+  uiPosition: 7
   icon:
     sprite: _CP14/Actions/Spells/fire.rsi
     state: flame_creation
@@ -72,7 +72,7 @@
   id: CP14SpellScrollBloodPurification
   faction: Thaumaturgy
   reputationLevel: 0
-  uiPosition: 9
+  uiPosition: 8
   icon:
     sprite: _CP14/Actions/Spells/healing.rsi
     state: cure_poison
@@ -83,7 +83,7 @@
   id: CP14SpellScrollSheepPolymorph
   faction: Thaumaturgy
   reputationLevel: 0
-  uiPosition: 10
+  uiPosition: 9
   icon:
     sprite: _CP14/Actions/Spells/misc.rsi
     state: polymorph
@@ -94,7 +94,7 @@
   id: CP14SpellScrollSearchOfLife
   faction: Thaumaturgy
   reputationLevel: 0
-  uiPosition: 11
+  uiPosition: 10
   icon:
     sprite: _CP14/Actions/Spells/light.rsi
     state: search_of_life
@@ -105,7 +105,7 @@
   id: CP14SpellScrollSphereOfLight
   faction: Thaumaturgy
   reputationLevel: 0
-  uiPosition: 12
+  uiPosition: 11
   icon:
     sprite: _CP14/Actions/Spells/light.rsi
     state: sphere_of_light
@@ -116,7 +116,7 @@
   id: CP14SpellScrollWaterCreation
   faction: Thaumaturgy
   reputationLevel: 0
-  uiPosition: 14
+  uiPosition: 12
   icon:
     sprite: _CP14/Actions/Spells/water.rsi
     state: water_creation
@@ -152,7 +152,7 @@
   faction: Thaumaturgy
   priceMarkup: 2
   reputationLevel: 1
-  uiPosition: 7
+  uiPosition: 6
   icon:
     sprite: _CP14/Actions/Spells/earth.rsi
     state: earth_wall
@@ -163,7 +163,7 @@
   id: CP14SpellScrollCureBurn
   faction: Thaumaturgy
   reputationLevel: 1
-  uiPosition: 9
+  uiPosition: 8
   icon:
     sprite: _CP14/Actions/Spells/healing.rsi
     state: cure_burn
@@ -174,12 +174,23 @@
   id: CP14SpellScrollCureWounds
   faction: Thaumaturgy
   reputationLevel: 1
-  uiPosition: 10
+  uiPosition: 9
   icon:
     sprite: _CP14/Actions/Spells/healing.rsi
     state: cure_wounds
   service: !type:CP14BuyItemsService
     product: CP14SpellScrollCureWounds
+
+- type: cp14TradingPosition
+  id: CP14SpellScrollResurrection
+  faction: Thaumaturgy
+  reputationLevel: 1
+  uiPosition: 10
+  icon:
+    sprite: _CP14/Actions/Spells/healing.rsi
+    state: resurrection
+  service: !type:CP14BuyItemsService
+    product: CP14SpellScrollResurrection
 
 - type: cp14TradingPosition
   id: CP14SpellScrollFlashLight
@@ -193,21 +204,10 @@
     product: CP14SpellScrollFlashLight
 
 - type: cp14TradingPosition
-  id: CP14SpellScrollResurrection
-  faction: Thaumaturgy
-  reputationLevel: 1
-  uiPosition: 13
-  icon:
-    sprite: _CP14/Actions/Spells/healing.rsi
-    state: resurrection
-  service: !type:CP14BuyItemsService
-    product: CP14SpellScrollResurrection
-
-- type: cp14TradingPosition
   id: CP14SpellScrollIceShards
   faction: Thaumaturgy
   reputationLevel: 1
-  uiPosition: 14
+  uiPosition: 12
   icon:
     sprite: _CP14/Actions/Spells/water.rsi
     state: ice_shards
@@ -221,7 +221,7 @@
   faction: Thaumaturgy
   reputationLevel: 2
   priceMarkup: 5
-  uiPosition: 8
+  uiPosition: 7
   icon:
     sprite: _CP14/Actions/Spells/fire.rsi
     state: fireball
@@ -233,7 +233,7 @@
   faction: Thaumaturgy
   priceMarkup: 5
   reputationLevel: 2
-  uiPosition: 14
+  uiPosition: 12
   icon:
     sprite: _CP14/Actions/Spells/water.rsi
     state: beer_creation
@@ -250,7 +250,7 @@
   priceMarkup: 15 #Unique trade spells
   faction: Thaumaturgy
   reputationLevel: 4
-  uiPosition: 6
+  uiPosition: 5
   icon:
     sprite: _CP14/Actions/Spells/dimension.rsi
     state: shadow_step


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Changed the positions of the skull vials in brads to be in line with the rest of the vials.
condensed the acadamy of thaum scrolls up so that none of them start off screen while keeping them in their rows and moved around flash and revive to be in better spots.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
on one of the first rounds with the revive changes the merchant nor an admin could find it in the store because it started off screen and there was no indication that there was more.
and brads just looked off with the skill vials like that.
## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->
<img width="817" height="745" alt="image" src="https://github.com/user-attachments/assets/288202a7-4533-4076-8dc1-d25efb716af5" />
<img width="794" height="749" alt="image" src="https://github.com/user-attachments/assets/441f6072-e8a2-4441-bc6d-483e40755926" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
-->
:cl:
- tweak: Changed Thaumaturgy and Brad's merchant contracts to have better UI.


