### PR TITLE
Make the magic vision effect better

### DIFF
--- a/Content.Client/_CP14/MagicVision/CP14MagicVisionOverlay.cs
+++ b/Content.Client/_CP14/MagicVision/CP14MagicVisionOverlay.cs
@@ -1,6 +1,8 @@
 using Content.Shared._CP14.MagicVision;
+using Content.Shared.CCVar;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
+using Robust.Shared.Configuration;
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
@@ -9,6 +11,7 @@ namespace Content.Client._CP14.MagicVision;
 
 public sealed class CP14MagicVisionOverlay : Overlay
 {
+    [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly IEntityManager _entityManager = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IPlayerManager _playerManager = default!;
@@ -23,13 +26,15 @@ public sealed class CP14MagicVisionOverlay : Overlay
     public TimeSpan StartOverlay = TimeSpan.Zero; // when the overlay started
 
     private const float PowerDivisor = 250.0f;
-    private const float Intensity = 0.2f; // for adjusting the visual scale
+    private float _intensity = 0.2f; // for adjusting the visual scale
     private float _visualScale = 0; // between 0 and 1
 
     public CP14MagicVisionOverlay()
     {
         IoCManager.InjectDependencies(this);
         _drowsinessShader = _prototypeManager.Index<ShaderPrototype>("Drowsiness").InstanceUnique();
+
+        _config.OnValueChanged(CCVars.ReducedMotion, OnReducedMotionChanged, invokeImmediately: true);
     }
 
     protected override void FrameUpdate(FrameEventArgs args)
@@ -45,7 +50,7 @@ public sealed class CP14MagicVisionOverlay : Overlay
         var curTime = _timing.CurTime;
         var timeLeft = (float)(curTime - StartOverlay).TotalSeconds;
 
-        CurrentPower = Math.Min(200f, 200f / Math.Max((float)timeLeft * 1.8f, 1.0f));
+        CurrentPower = Math.Min(150f, 150f / Math.Max((float)timeLeft * 1.8f, 1.0f));
     }
 
     protected override bool BeforeDraw(in OverlayDrawArgs args)
@@ -60,6 +65,11 @@ public sealed class CP14MagicVisionOverlay : Overlay
         return _visualScale >= 0;
     }
 
+    private void OnReducedMotionChanged(bool reducedMotion)
+    {
+        _intensity = reducedMotion ? 0f : 0.2f;
+    }
+
     protected override void Draw(in OverlayDrawArgs args)
     {
         if (ScreenTexture == null)
@@ -67,7 +77,7 @@ public sealed class CP14MagicVisionOverlay : Overlay
 
         var handle = args.WorldHandle;
         _drowsinessShader.SetParameter("SCREEN_TEXTURE", ScreenTexture);
-        _drowsinessShader.SetParameter("Strength", _visualScale * Intensity);
+        _drowsinessShader.SetParameter("Strength", _visualScale * _intensity);
         handle.UseShader(_drowsinessShader);
         handle.DrawRect(args.WorldBounds, Color.White);
         handle.UseShader(null);


### PR DESCRIPTION
## About the PR
Now magic vision effect is becoming weaker over time
It can be turned off via "Reduced Motion" setting

## Why / Balance
resolve (partially) #1738 

## Media
https://github.com/user-attachments/assets/325259c5-b4c3-486b-ba36-fa9b048e3a36

**Changelog**
:cl: 
- tweak: Magic vision effect becomes weaker over time. It can be turned off via "Reduced Motion" setting