### PR TITLE
Nerf fire trap

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/fire_trap.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Fire/fire_trap.yml
@@ -117,9 +117,9 @@
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: FireBomb
-    totalIntensity: 10.0
-    intensitySlope: 4
-    maxIntensity: 3
+    totalIntensity: 8.0
+    intensitySlope: 3
+    maxIntensity: 2
   - type: DeleteOnTrigger
 
 - type: entity
@@ -134,7 +134,7 @@
 - type: entity
   parent: CP14SpawnMagicFireTrap
   id: CP14SpawnMagicFireTrapInvisible
-  suffix: Invisible. Permanent
+  suffix: Invisible. Permanent. Admin
   components:
   - type: Visibility
     layer: 16

--- a/Resources/Prototypes/_CP14/Procedural/Demiplane/Modifiers/Danger/trap.yml
+++ b/Resources/Prototypes/_CP14/Procedural/Demiplane/Modifiers/Danger/trap.yml
@@ -31,30 +31,18 @@
       maxGroupSize: 1
 
 - type: cp14LocationModifier
-  id: FireTrapInvisible
-  levels:
-    min: 3
-    max: 10
-  categories:
-    Danger: 0.1
-  layers:
-    - !type:CP14OreDunGen
-      entity: CP14SpawnMagicFireTrapInvisible
-      count: 5
-      minGroupSize: 1
-      maxGroupSize: 1
-
-- type: cp14LocationModifier
   id: FireTrapPermanent
   levels:
-    min: 3
+    min: 5
     max: 10
   categories:
-    Danger: 0.1
+    Danger: 0.15
+  blacklistTags:
+  - CP14DemiplaneCold
   layers:
     - !type:CP14OreDunGen
       entity: CP14SpawnMagicFireTrapPermanent
-      count: 10
+      count: 6
       minGroupSize: 1
       maxGroupSize: 1
 


### PR DESCRIPTION
## About the PR

Removes invisible fire traps from the spawn of demiplanes and weakens them. Invisible fire traps remain in the spawn for admins.
Убирает невидимые огненные ловушки из спавна демипланов, и ослабляет их. Невидимые огненные ловушки остаются в спавне для админов.

## Why / Balance

Players suffer greatly, and the price of mistakes is high.
Игроки сильно страдают, и высокая цена ошибки.

**Changelog**

:cl:
- remove: Removes invisible fire traps from spawns in demiplanes.
