### PR TITLE
add passive heal

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/Species/base.yml
@@ -256,13 +256,14 @@
   - type: PassiveDamage
     allowedStates:
     - Alive
-    damageCap: 20
+    damageCap: 80
     damage:
       types:
-        Heat: -0.07
         CP14ManaDepletion: -0.05
       groups:
         Brute: -0.07
+        Burn: -0.05
+        Toxin: -0.03
   - type: StatusEffects
     allowed:
     - Stun

--- a/Resources/Prototypes/_CP14/Entities/Mobs/Species/elf.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/Species/elf.yml
@@ -9,13 +9,14 @@
   - type: PassiveDamage
     allowedStates:
     - Alive
-    damageCap: 20
+    damageCap: 80
     damage:
       types:
-        Heat: -0.07
-        CP14ManaDepletion: -0.07
+        CP14ManaDepletion: -0.1
       groups:
         Brute: -0.07
+        Burn: -0.05
+        Toxin: -0.03
   - type: Icon
     sprite: _CP14/Mobs/Species/Elf/parts.rsi
     state: full

--- a/Resources/Prototypes/_CP14/Entities/Mobs/Species/goblin.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/Species/goblin.yml
@@ -107,6 +107,7 @@
       groups:
         Burn: -0.2
         Brute: -0.2
+        Toxin: -0.05
   - type: Stamina
     decay: 5 # 3 default
     critThreshold: 120 # 100 default

--- a/Resources/Prototypes/_CP14/Entities/Mobs/Species/tiefling.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/Species/tiefling.yml
@@ -19,13 +19,17 @@
     damageContainer: CP14Biological
     damageModifierSet: CP14Tiefling
   - type: PassiveDamage
-    damageCap: 0
+    damageCap: 80
     allowedStates:
     - Alive
-    - Critical
     damage:
       types:
-        Heat: -0.14 # Around 8 damage a minute healed
+        Heat: -0.14 # Around 8 damage a minute healed (9.6 with burn regeneration below)
+        CP14ManaDepletion: -0.05
+      groups:
+        Brute: -0.05
+        Burn: -0.02
+        Toxin: -0.03
   - type: CP14MagicEnergyDraw
     energy: 0.75
     delay: 3 # 5m to full restore


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Теперь все расы восстанавливают здоровье, пока урон не достигнет 80.
- также тифлинги теперь регенерируют не только ожоги

Now all races restore health until the damage reaches 80.
- also, tieflings now regenerate not only burns

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Люди много говорят о том что нужно добавить больше способов лечения через крафтабельные лечилки, но я посмотрел в дизайн документ и увидел, что лечение до крита не должно тратить ресурсы, более того в примере есть пассивная регенерация.
Если же эти цифры окажутся велики, мы всегда можем сделать их меньше 

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->

**Changelog**
 Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.

:cl:
- tweak: Now all races restore health until the damage reaches 80!
