### PR TITLE
Rat faction (CityAnimals)

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Mobs/NPC/rat.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/NPC/rat.yml
@@ -10,9 +10,9 @@
       task: RuminantHostileCompound
   - type: NpcFactionMember
     factions:
-    - CP14PeacefulAnimals
+    - CP14CityAnimals
   - type: NPCRetaliation
-    attackMemoryLength: 30
+    attackMemoryLength: 20
   - type: Sprite
     drawdepth: SmallMobs
     layers:

--- a/Resources/Prototypes/_CP14/ai_factions.yml
+++ b/Resources/Prototypes/_CP14/ai_factions.yml
@@ -19,6 +19,7 @@
   - CP14Monster
   - CP14Slimes
   - CP14Fishies
+  - CP14CityAnimals
 
 - type: npcFaction
   id: CP14Undead
@@ -28,6 +29,7 @@
   - CP14PeacefulAnimals
   - CP14AggressiveAnimals
   - CP14Fishies
+  - CP14CityAnimals
 
 - type: npcFaction
   id: CP14PeacefulAnimals
@@ -45,6 +47,7 @@
   - CP14Slimes
   - CP14HostileEveryone
   - CP14Fishies
+  - CP14CityAnimals
 
 - type: npcFaction
   id: CP14Monster
@@ -53,6 +56,7 @@
   - CP14HostileEveryone
   - CP14AggressiveAnimals
   - CP14PeacefulAnimals
+  - CP14CityAnimals
 
 - type: npcFaction
   id: CP14Insects
@@ -69,6 +73,7 @@
   - CP14HostileEveryone
   - CP14PeacefulAnimals
   - CP14AggressiveAnimals
+  - CP14CityAnimals
 
 - type: npcFaction
   id: CP14Fishies
@@ -79,3 +84,14 @@
   - CP14AggressiveAnimals
   - CP14Insects
   - CP14Undead
+  - CP14CityAnimals
+
+- type: npcFaction
+  id: CP14CityAnimals
+  hostile:
+  - CP14HostileEveryone
+  - CP14AggressiveAnimals
+  - CP14Undead
+  - CP14Monster
+  - CP14Slimes
+  - CP14Fishies


### PR DESCRIPTION
## About the PR

Adds a new faction for animals in the city. Currently used on rats, may be used on pets in the future.
Добавляет новую фракцию для животных в городе. Сейчас используется на крысе, в будущем может быть использована на питомцах.

## Why / Balance

Now, the rat is no one's enemy. This could lead to the rat heroically slaughtering all the demiplanes in one fell swoop.
Сейчас крыса никому не враг. Это может привести к героической резни крысой всех демипланов в одну морду.

**Changelog**
