### PR TITLE
Microbalance of Vampires

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Vampire/hypnosys.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Vampire/hypnosys.yml
@@ -4,6 +4,8 @@
   name: Hypnosys
   description: You focus on the target, mesmerizing and lulling it to sleep.
   components:
+  - type: CP14ActionDoAfterSlowdown
+    speedMultiplier: 0.4
   - type: CP14MagicEffectVampire
   - type: CP14ActionManaCost
     manaCost: 5


### PR DESCRIPTION
## About the PR

Now, during Hypnosis, the vampire cannot move.
Теперь во время Гипноза, вампир не может двигаться.

## Why / Balance

Vampire hypnosis is a very powerful ability that leaves the victim unable to defend themselves. This change will give the victim a chance to escape and may force vampires to attack smaller groups in large teams.
And also to prevent vampires from fighting large groups so easily. While one vampire keeps one opponent hypnotised, his participation in the battle will be more limited.
Гипноз вампиров это очень мощная способность, не дающая жертве возможности никак защищаться. Это изменение даст возможность жертве спастись, и может заставить вампиров нападать большой командой на меньшие группы.
А также не дать вампирам так просто сражаться с большими группами. Пока один из вампиром держит под гипнозом одного противника, его участие в битве будет более ограниченным.

**Changelog**

:cl:
- tweak: Vampire hypnosis is break if the vampire starts walking.
