### PR TITLE
Armor Damage Absorption

### DIFF
--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -394,7 +394,7 @@ namespace Content.Shared.Damage
         }
     }
 
-    public sealed class DamageChangedEvent : EntityEventArgs
+    public sealed class DamageChangedEvent : EntityEventArgs, IInventoryRelayEvent
     {
         /// <summary>
         ///     This is the component whose damage was changed.
@@ -448,5 +448,9 @@ namespace Content.Shared.Damage
             }
             InterruptsDoAfters = interruptsDoAfters && DamageIncreased;
         }
+
+        //CP14
+        public SlotFlags TargetSlots => SlotFlags.All;
+        //CP14 end
     }
 }

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -45,6 +45,7 @@ public partial class InventorySystem
         SubscribeLocalEvent<InventoryComponent, CP14MagicEssenceScanEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, CP14CalculateManacostEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, CP14SkillScanEvent>(RelayInventoryEvent);
+        SubscribeLocalEvent<InventoryComponent, DamageChangedEvent>(RelayInventoryEvent);
         //CP14 End
 
         SubscribeLocalEvent<InventoryComponent, DamageModifyEvent>(RelayInventoryEvent);

--- a/Content.Shared/_CP14/Armor/CP14ArmorDamageAbsorptionComponent.cs
+++ b/Content.Shared/_CP14/Armor/CP14ArmorDamageAbsorptionComponent.cs
@@ -1,0 +1,15 @@
+using Content.Shared._CP14.Actions;
+using Content.Shared.Damage;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._CP14.Armor;
+
+/// <summary>
+/// When the wearer takes damage, part of that damage is also taken by this item of clothing.
+/// </summary>
+[RegisterComponent, NetworkedComponent, Access(typeof(CP14ArmorSystem))]
+public sealed partial class CP14ArmorDamageAbsorptionComponent : Component
+{
+    [DataField]
+    public float Absorption = 0.3f;
+}

--- a/Content.Shared/_CP14/Armor/CP14ArmorSystem.cs
+++ b/Content.Shared/_CP14/Armor/CP14ArmorSystem.cs
@@ -1,0 +1,28 @@
+
+using Content.Shared.Damage;
+using Content.Shared.Inventory;
+
+namespace Content.Shared._CP14.Armor;
+
+public sealed class CP14ArmorSystem : EntitySystem
+{
+    [Dependency] private readonly DamageableSystem _damageable = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<CP14ArmorDamageAbsorptionComponent, InventoryRelayedEvent<DamageChangedEvent>>(OnDamageChanged);
+    }
+
+    private void OnDamageChanged(Entity<CP14ArmorDamageAbsorptionComponent> ent, ref InventoryRelayedEvent<DamageChangedEvent> args)
+    {
+        if (!args.Args.DamageIncreased)
+            return;
+
+        if (args.Args.DamageDelta is null)
+            return;
+
+        _damageable.TryChangeDamage(ent, args.Args.DamageDelta * ent.Comp.Absorption);
+    }
+}

--- a/Resources/Prototypes/_CP14/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/_CP14/Entities/Clothing/Back/backpacks.yml
@@ -57,13 +57,6 @@
       CP14Leather: 18 # 20u CP14Leather (4x5u) ~~~ and -2u for cost balance
       CP14Iron: 2 # 2u CP14IronBuckle (1x2u)
       # Cost: (20×1.2) + (2×2) = 24 + 4 = 28 copper coins
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.95
-        Slash: 0.95
-        Heat: 0.90
-        Caustic: 0.90
   - type: ExplosionResistance
     damageCoefficient: 0.9
 

--- a/Resources/Prototypes/_CP14/Entities/Clothing/Back/backpacks_satchels.yml
+++ b/Resources/Prototypes/_CP14/Entities/Clothing/Back/backpacks_satchels.yml
@@ -108,11 +108,6 @@
       CP14Iron: 12 # 12u CP14IronBuckle (6x2u)
       CP14Cloth: 50 # 40u CP14Cloth (8x10u) + 10u CP14String ~~~ 15 additional coppers
       # Cost: (45×1.2) + (12×2) = 54 + 24 = 78 copper coins
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.95
-        Slash: 0.95
   - type: StaticPrice
     price: 30 # Balance with backpack
 
@@ -139,11 +134,6 @@
       CP14Iron: 12 # 12u CP14IronBuckle (6x2u)
       CP14Cloth: 50 # 40u CP14Cloth (8x10u) + 10u CP14String ~~~ 15 additional coppers
       # Cost: (80×1.2) + (12×2) = 96 + 24 = 120 copper coins
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.90
-        Slash: 0.90
   - type: ExplosionResistance
     damageCoefficient: 0.9
   - type: ClothingSpeedModifier
@@ -180,11 +170,5 @@
       CP14Leather: 45 # 15u thin (3x5u) + 30u regular (3x10u)
       CP14Iron: 32 # 20 + 12u CP14IronBuckle (6x2u)
       # Cost: (45×1.2) + (32×2) = 54 + 64 = 118 copper coins
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.90
-        Slash: 0.90
-        Piercing: 0.95
   - type: ExplosionResistance
     damageCoefficient: 0.85

--- a/Resources/Prototypes/_CP14/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_CP14/Entities/Clothing/OuterClothing/armor.yml
@@ -127,6 +127,9 @@
     sprintModifier: 0.90
   - type: CP14MagicManacostModify
     globalModifier: 1.2
+  - type: CP14ArmorDamageAbsorption
+    absorption: 0.5
   - type: PhysicalComposition
     materialComposition:
       CP14Iron: 90
+  - type: Damageable


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Armor now can take part  of damage that owner get

TODO: 
some content

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.

:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
