### PR TITLE
Fixs zombie and loot

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Markers/Spawners/mobs.yml
+++ b/Resources/Prototypes/_CP14/Entities/Markers/Spawners/mobs.yml
@@ -22,6 +22,8 @@
         - id: CP14MobUndeadZombieGearEasy1
         - id: CP14MobUndeadZombieGearEasy2
         - id: CP14MobUndeadZombieGearEasy3
+        - id: CP14MobUndeadZombieGearEasy4
+        - id: CP14MobUndeadZombieGearEasy5
 
 # Animal
 

--- a/Resources/Prototypes/_CP14/Entities/Mobs/NPC/zombie.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/NPC/zombie.yml
@@ -16,6 +16,8 @@
   - type: NpcFactionMember
     factions:
     - CP14Monster
+  - type: RandomHumanoidAppearance
+    randomizeName: false
   - type: NPCImprintingOnSpawnBehaviour
     whitelist:
       tags:
@@ -48,3 +50,20 @@
   - type: Loadout
     prototypes: [ CP14MobUndeadEasy3 ]
 
+- type: entity
+  id: CP14MobUndeadZombieGearEasy4
+  parent: CP14MobUndeadZombie
+  suffix: Zombie. Easy
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Loadout
+    prototypes: [ CP14MobUndeadEasy4 ]
+
+- type: entity
+  id: CP14MobUndeadZombieGearEasy5
+  parent: CP14MobUndeadZombie
+  suffix: Zombie. Easy
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Loadout
+    prototypes: [ CP14MobUndeadEasy5 ]

--- a/Resources/Prototypes/_CP14/Entities/Mobs/Species/zombie.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/Species/zombie.yml
@@ -29,8 +29,8 @@
     - map: [ "enum.HumanoidVisualLayers.RHand" ]
     - map: [ "gloves" ]
     - map: [ "ears" ]
-    - map: [ "cloak" ]
     - map: [ "outerClothing" ]
+    - map: [ "cloak" ]
     - map: [ "eyes" ]
     - map: [ "belt" ]
     - map: [ "belt2" ]
@@ -185,10 +185,10 @@
         sizeMaps:
           32:
             sprite: _CP14/Mobs/Species/Human/displacement.rsi
-            state: male_neck
+            state: female_neck
           48:
             sprite: _CP14/Mobs/Species/Human/displacement48.rsi
-            state: male_neck
+            state: female_neck
 
 - type: entity
   parent: CP14BaseSpeciesDummy
@@ -238,7 +238,7 @@
         sizeMaps:
           32:
             sprite: _CP14/Mobs/Species/Human/displacement.rsi
-            state: male_neck
+            state: female_neck
           48:
             sprite: _CP14/Mobs/Species/Human/displacement48.rsi
-            state: male_neck
+            state: female_neck

--- a/Resources/Prototypes/_CP14/Entities/Objects/Economy/wallet.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Economy/wallet.yml
@@ -95,6 +95,3 @@
       orGroup: ZombieLootT1
     - id: CP14CopperCoin1
       orGroup: ZombieLootT1
-    - id: CP14LockIron
-      prob: 0.05
-      orGroup: ZombieLootT1

--- a/Resources/Prototypes/_CP14/Entities/Objects/Economy/wallet.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Economy/wallet.yml
@@ -39,6 +39,11 @@
     slots: [belt]
   - type: Item
     size: Normal
+  - type: Butcherable
+    butcheringType: Knife
+    spawned:
+    - id: CP14ScrapLeather
+      amount: 1
 
 - type: entity
   id: CP14WalletFilledTest
@@ -69,3 +74,27 @@
     - id: CP14CopperCoin
     - id: CP14CopperCoin
 
+- type: entity
+  id: CP14WalletFilledLootT1
+  parent: CP14Wallet
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: StorageFill
+    contents:
+    - id: CP14GoldCoin1
+      prob: 0.001
+      orGroup: ZombieLootT1
+    - id: CP14SilverCoin5
+      prob: 0.1
+      orGroup: ZombieLootT1
+    - id: CP14SilverCoin1
+      prob: 0.3
+      orGroup: ZombieLootT1
+    - id: CP14CopperCoin5
+      prob: 0.6
+      orGroup: ZombieLootT1
+    - id: CP14CopperCoin1
+      orGroup: ZombieLootT1
+    - id: CP14LockIron
+      prob: 0.05
+      orGroup: ZombieLootT1

--- a/Resources/Prototypes/_CP14/InventoryTemplates/partial_inventory_template.yml
+++ b/Resources/Prototypes/_CP14/InventoryTemplates/partial_inventory_template.yml
@@ -3,17 +3,17 @@
   slots:
     # Left hotbar
     # 0, y
-    - name: neck
-      slotTexture: neck
-      slotFlags: NECK
-      uiWindowPos: 0,0
-      strippingWindowPos: 1,2
-      displayName: Neck
+    - name: gloves
+      slotTexture: gloves
+      slotFlags: GLOVES
+      uiWindowPos: 0,1
+      strippingWindowPos: 0,2
+      displayName: Gloves
     - name: mask
       slotTexture: mask
       slotFlags: MASK
-      uiWindowPos: 2,3
-      strippingWindowPos: 2,1
+      uiWindowPos: 0,2
+      strippingWindowPos: 2,0
       displayName: Mask
     - name: eyes
       slotTexture: eyes
@@ -22,12 +22,6 @@
       strippingWindowPos: 0,1
       displayName: Eyes
     # 1, y
-    - name: shoes
-      slotTexture: shoes
-      slotFlags: FEET
-      uiWindowPos: 1,0
-      strippingWindowPos: 1,5
-      displayName: Shoes
     - name: pants
       slotTexture: pants
       slotFlags: PANTS
@@ -47,21 +41,18 @@
       strippingWindowPos: 1,1
       displayName: Head
     # 2, y
-    - name: gloves
-      slotTexture: gloves
-      slotFlags: GLOVES
-      uiWindowPos: 2,0
-      strippingWindowPos: 0,2
-      displayName: Gloves
+    - name: shoes
+      slotTexture: shoes
+      slotFlags: FEET
+      uiWindowPos: 2,1
+      strippingWindowPos: 1,5
+      displayName: Shoes
     - name: outerClothing
       slotTexture: suit
       slotFlags: OUTERCLOTHING
-      uiWindowPos: 2,1
-      strippingWindowPos: 2,3
+      uiWindowPos: 2,2
+      strippingWindowPos: 2,1
       displayName: Armor
-      blacklist:
-        tags:
-          - PetOnly
     - name: cloak
       slotTexture: cloak
       slotFlags: CLOAK
@@ -86,6 +77,14 @@
       dependsOn: pants
       displayName: Keys
       stripHidden: true
+    - name: neck
+      slotTexture: neck
+      slotFlags: NECK
+      slotGroup: SecondHotbar
+      uiWindowPos: 0,0
+      strippingWindowPos: 1,2
+      displayName: Neck
+      dependsOn: shirt
     # Right hand
     # Left hand
     - name: belt2

--- a/Resources/Prototypes/_CP14/Loadouts/Misc/undead_startinggear.yml
+++ b/Resources/Prototypes/_CP14/Loadouts/Misc/undead_startinggear.yml
@@ -3,10 +3,12 @@
   equipment:
     shirt: CP14ClothingShirtCottonBlack
     pants: CP14ClothingPantsTrouserDarkBlue
+    belt: CP14WalletFilledLootT1
 
 - type: startingGear
   id: CP14MobUndeadEasy2
   equipment:
+    head: CP14ClothingHeadMetalHeadband
     pants: CP14ClothingPantsLoincloth
 
 - type: startingGear
@@ -16,3 +18,15 @@
     shoes: CP14ClothingShoesSandals
     mask: CP14ClothingMaskSinner
 
+- type: startingGear
+  id: CP14MobUndeadEasy4
+  equipment:
+    cloak: CP14ClothingCloakRitualAttireLeather
+    pants: CP14ClothingPantsGreen
+
+- type: startingGear
+  id: CP14MobUndeadEasy5
+  equipment:
+    pants: CP14ClothingPantsBrown
+    outerClothing: CP14ClothingOuterClothingBrownVest1
+    belt: CP14WalletFilledLootT1

--- a/Resources/Prototypes/_CP14/Species/zombie.yml
+++ b/Resources/Prototypes/_CP14/Species/zombie.yml
@@ -17,7 +17,6 @@
   sprites:
     Head: CP14MobZombieHead
     Chest: CP14MobZombieTorso
-    Eyes: CP14MobZombieEyes
     LArm: CP14MobZombieLArm
     RArm: CP14MobZombieRArm
     LHand: CP14MobZombieLHand
@@ -26,12 +25,6 @@
     RLeg: CP14MobZombieRLeg
     LFoot: CP14MobZombieLFoot
     RFoot: CP14MobZombieRFoot
-
-- type: humanoidBaseSprite
-  id: CP14MobZombieEyes
-  baseSprite:
-    sprite: _CP14/Mobs/Customization/eyes.rsi
-    state: eyes
 
 - type: humanoidBaseSprite
   id: CP14MobZombieHead


### PR DESCRIPTION
## About the PR

Fixed a very old bug: walking dead can now be female. Added a couple of new clothing options for the dead and some small loot. Made normal display of clothing slots for walking dead and mannequin.
Починил очень давнюю ошибку, ходячие мертвецы теперь могут быть и женского пола. Добавил пару новых вариантов одежды для мертвецов и небольшой лут. Сделал нормальное отображение слотов одежды у ходячих мертвецов и манекена.

## Why / Balance

A little more loot from the walking dead, for adventurers to earn money.
Чуть больше лута с ходячих мертвецов, для заработка авантюристам.

## Media

<img width="436" height="316" alt="изображение" src="https://github.com/user-attachments/assets/47326f3e-ad48-4747-a570-4f9749be9ef7" />

**Changelog**

:cl:
- add: Adds money to the wallets of some walking dead.
- tweak: Wallets can be cut into scraps of leather.
- fix: The walking dead can be women.
