### PR TITLE
Magic now respect physics again

### DIFF
--- a/Content.Shared/Actions/SharedActionsSystem.DoAfter.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.DoAfter.cs
@@ -1,6 +1,8 @@
 ﻿using Content.Shared._CP14.Actions;
+using Content.Shared.Actions.Components;
 using Content.Shared.Actions.Events;
 using Content.Shared.DoAfter;
+using Content.Shared.Item;
 
 namespace Content.Shared.Actions;
 
@@ -22,13 +24,21 @@ public abstract partial class SharedActionsSystem
         var netEnt = GetNetEntity(performer);
 
         //CP14 doAfter start event
+        var target = GetEntity(input.EntityTarget);
+        EntityUid? used = null;
+
+        if (TryComp<ActionComponent>(ent, out var action) && HasComp<ItemComponent>(action.Container))
+        {
+            used = action.Container;
+        }
+
         var cp14StartEv = new CP14ActionStartDoAfterEvent(netEnt, input);
         RaiseLocalEvent(ent, cp14StartEv);
         //CP14 end
 
         var actionDoAfterEvent = new ActionDoAfterEvent(netEnt, originalUseDelay, input);
 
-        var doAfterArgs = new DoAfterArgs(EntityManager, performer, delay, actionDoAfterEvent, ent.Owner, performer)
+        var doAfterArgs = new DoAfterArgs(EntityManager, performer, delay, actionDoAfterEvent, ent.Owner, target ?? performer, used) //CP14 edited target and added used
         {
             AttemptFrequency = ent.Comp.AttemptFrequency,
             Broadcast = ent.Comp.Broadcast,
@@ -73,6 +83,11 @@ public abstract partial class SharedActionsSystem
         {
             SetUseDelay(action, TimeSpan.Zero);
         }
+
+        //CP14 start delay after cancelling for preventing spamming
+        if (args.Cancelled)
+            StartUseDelay(action);
+        //CP14 end
 
         if (args.Cancelled)
             return;

--- a/Resources/Prototypes/_CP14/Species/silva.yml
+++ b/Resources/Prototypes/_CP14/Species/silva.yml
@@ -11,6 +11,10 @@
   maleFirstNames: CP14_Names_Silva_Male_First
   femaleFirstNames: CP14_Names_Silva_Female_First
   naming: First
+  requirements:
+    - !type:TraitsRequirement 
+      traits:
+        - CP14Blindness
 
 - type: speciesBaseSprites
   id: CP14MobSilvaSprites

--- a/Resources/Prototypes/_CP14/Species/silva.yml
+++ b/Resources/Prototypes/_CP14/Species/silva.yml
@@ -11,10 +11,6 @@
   maleFirstNames: CP14_Names_Silva_Male_First
   femaleFirstNames: CP14_Names_Silva_Female_First
   naming: First
-  requirements:
-    - !type:TraitsRequirement 
-      traits:
-        - CP14Blindness
 
 - type: speciesBaseSprites
   id: CP14MobSilvaSprites


### PR DESCRIPTION
fix #1795

:cl:
- fix: Spells are interrupted again if players move far away from target or drop the item used for casting, or loses sight of the target
- fix: After an interrupted spell cast, the cooldown begins again, preventing spamming. 

