### PR TITLE
Hotfix

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Actions/Spells/Lurker/Kick.yml
+++ b/Resources/Prototypes/_CP14/Entities/Actions/Spells/Lurker/Kick.yml
@@ -8,7 +8,7 @@
     stamina: 20
   - type: DoAfterArgs
     delay: 2.5
-    distanceThreshold: 1.5
+    distanceThreshold: 2.5
     breakOnDamage: true
   - type: CP14ActionEmoting
     startEmote: cp14-kick-lurker-start

--- a/Resources/Prototypes/_CP14/Entities/Mobs/NPC/fairy.yml
+++ b/Resources/Prototypes/_CP14/Entities/Mobs/NPC/fairy.yml
@@ -3,7 +3,7 @@
   parent: CP14SimpleMobBase
   id: CP14MobFairy
   description: It glows, squeaks and considers itself very important. It seems that ordinary weapons are incapable of killing her, and only the dissipation of magic will help.
-  categories: [ ForkFiltered ]
+  categories: [ ForkFiltered, HideSpawnMenu ] #Disable spawn in spawmenu
   components:
   - type: MovementSpeedModifier
     baseWalkSpeed : 2

--- a/Resources/Prototypes/_CP14/Procedural/Demiplane/Modifiers/Danger/mobs.yml
+++ b/Resources/Prototypes/_CP14/Procedural/Demiplane/Modifiers/Danger/mobs.yml
@@ -38,21 +38,21 @@
       minGroupSize: 2
       maxGroupSize: 6
 
-- type: cp14LocationModifier
-  id: Fairy
-  levels:
-    min: 0
-    max: 3
-  categories:
-    Danger: 0.20
-  requiredTags:
-  - CP14DemiplaneHerbals
-  layers:
-    - !type:CP14OreDunGen
-      entity: CP14MobFairy
-      count: 4
-      minGroupSize: 2
-      maxGroupSize: 3
+#- type: cp14LocationModifier #Temporarily disabled until fairies can crash server
+#  id: Fairy
+#  levels:
+#    min: 0
+#    max: 3
+#  categories:
+#    Danger: 0.20
+#  requiredTags:
+#  - CP14DemiplaneHerbals
+#  layers:
+#    - !type:CP14OreDunGen
+#      entity: CP14MobFairy
+#      count: 4
+#      minGroupSize: 2
+#      maxGroupSize: 3
 
 - type: cp14LocationModifier
   id: SmallHydra


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
fix #1809

and temp disable magic fairies, because they can crash server

:cl:
- remove: Disabled magic fairies until fix, becaues they cause server crashes
- fix: Fixed lurker melee stun interrupting

