### PR TITLE
small alchemy QOL

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Objects/Specific/Alchemy/vials.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Specific/Alchemy/vials.yml
@@ -53,7 +53,7 @@
     - 1
     - 5
     - 10
-    currentTransferAmount: 1
+    currentTransferAmount: 5
     toggleState: 1 # draw
   - type: Tag
     tags:


### PR DESCRIPTION
## About the PR
the vials now start transfering at 5u, instead of 1u

## Why / Balance
<img width="1197" height="86" alt="image" src="https://github.com/user-attachments/assets/199b37db-4988-45d8-a3ed-7119a2964824" />

**Changelog**
- tweak: The vials now start transfering at 5u, instead of 1u
