### PR TITLE
Remove duplicate spell on electric staff

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Objects/Weapons/Magic/twoHandedStaffs.yml
+++ b/Resources/Prototypes/_CP14/Entities/Objects/Weapons/Magic/twoHandedStaffs.yml
@@ -118,7 +118,6 @@
     - CP14ActionSpellElectricTrap
     - CP14ActionSpellLightningStrike
     - CP14ActionSpellLightningStrikeSmall
-    - CP14ActionSpellLightningStrikeSmall
   - type: Sprite
     sprite: _CP14/Objects/Weapons/Magic/TwoHandedStaff/guard_electro_staff.rsi
   - type: Clothing


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Removed duplicate instance of CP14ActionSpellLightningStrikeSmall spell from electric staff.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Bugfix, duplicate spells just clog actions bar.
## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.

:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
