### PR TITLE
fixed: server crashes when using instant fire explosion entity on dead entities

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Effects/admin_triggers.yml
+++ b/Resources/Prototypes/_CP14/Entities/Effects/admin_triggers.yml
@@ -10,6 +10,7 @@
     maxIntensity: 400
     explosionType: FireBomb
   - type: ExplodeOnTrigger
+    targetUser: false
 
 - type: entity
   id: CP14ShipExplosionBig
@@ -23,7 +24,8 @@
     maxIntensity: 400
     explosionType: Default
   - type: ExplodeOnTrigger
+    targetUser: false
   - type: FlashOnTrigger
     range: 30
-  - type: SpawnOnTrigger 
+  - type: SpawnOnTrigger
     proto: GrenadeFlashEffect


### PR DESCRIPTION

## About the PR
Fixes #1823

fixed the bug by setting targetUser to false in the explodeontrigger component

**Changelog**

:cl: kin98

- fix: fixed server crash using explosion admin tool on dead enities
