### PR TITLE
small alchemy QOL

### DIFF
--- a/Resources/Prototypes/_CP14/Entities/Structures/Specific/Alchemy/cleaner.yml
+++ b/Resources/Prototypes/_CP14/Entities/Structures/Specific/Alchemy/cleaner.yml
@@ -68,6 +68,7 @@
   - type: CP14SolutionCleaner
     solution: cleaner
     leakageQuantity: 1
+    updateFrequency: 2.5
   - type: CP14MagicEnergyAmbientSound
   - type: AmbientSound
     enabled: false
@@ -80,6 +81,6 @@
     maxFillLevels: 5
     fillBaseName: liq-
   - type: CP14MagicEnergyDraw
-    energy: -0.8
+    energy: -1.1
     delay: 1
 


### PR DESCRIPTION
## About the PR
Solution cleaner works faster now(1.6 times if to be precise), but uses more mana.

## Why / Balance
It uses 50% of mana in the crystal for deleting 10u, which seems fair. now you don't need to wait almost a minute while it's working

**Changelog**
:cl: oldschool_otaku
- tweak: Solution cleaner works faster now(1.75x if to be precise), but uses more mana.
