### PR TITLE
Player igniting something show red message in chat for admins 

### DIFF
--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -360,9 +360,9 @@ namespace Content.Server.Atmos.EntitySystems
             if (flammable.FireStacks > 0 && !flammable.OnFire)
             {
                 if (ignitionSourceUser != null)
-                    _adminLogger.Add(LogType.Flammable, $"{ToPrettyString(uid):target} set on fire by {ToPrettyString(ignitionSourceUser.Value):actor} with {ToPrettyString(ignitionSource):tool}");
+                    _adminLogger.Add(LogType.Flammable, LogImpact.Extreme, $"{ToPrettyString(uid):target} set on fire by {ToPrettyString(ignitionSourceUser.Value):actor} with {ToPrettyString(ignitionSource):tool}");
                 else
-                    _adminLogger.Add(LogType.Flammable, $"{ToPrettyString(uid):target} set on fire by {ToPrettyString(ignitionSource):actor}");
+                    _adminLogger.Add(LogType.Flammable, LogImpact.Extreme, $"{ToPrettyString(uid):target} set on fire by {ToPrettyString(ignitionSource):actor}");
                 flammable.OnFire = true;
 
                 var extinguished = new IgnitedEvent();

--- a/Content.Server/_CP14/Temperature/CP14FireSpreadSystem.cs
+++ b/Content.Server/_CP14/Temperature/CP14FireSpreadSystem.cs
@@ -60,7 +60,14 @@ public sealed partial class CP14FireSpreadSystem : CP14SharedFireSpreadSystem
         if (args.Cancelled || args.Handled)
             return;
 
-        _flammable.AdjustFireStacks(ent, ent.Comp.FirestacksOnIgnite, ent.Comp, true);
+        _flammable.AdjustFireStacks(ent, ent.Comp.FirestacksOnIgnite);
+
+        if (args.Used is EntityUid ignitionSource)
+            // Used a Entity for ignition
+            _flammable.Ignite(ent, ignitionSource, ent.Comp, args.User);
+        else
+            // Did not use a Entity for ignition
+            _flammable.Ignite(ent, args.User, ent.Comp);
 
         args.Handled = true;
     }


### PR DESCRIPTION
## About the PR
Replaces #1829 couse i made a oopsy

I changed how the flammable system igniting method creates admin logs. It now has an logimpact of extreme that way it will give admins a message in their chat.

i also made enitites that are using the component delayedIgnitionSource also create admin logs

there are other enitites or components that dont call the ignite method which will have to be changed if its wanted that they also get logged
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
fix for #1235 
## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
-->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.

:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
